### PR TITLE
ci(publish): setup github action to publish packages

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,3 +22,21 @@ jobs:
           yarn test:all:no-watch
           yarn tsc
           yarn build:all
+  publish:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Publish package
+        run: |
+          yarn install
+          yarn tsc
+          yarn build:all
+          yarn lerna publish from-package --yes
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This pull request adds the publish job, which will run `yarn lerna publish --from-package --yes` to release new package versions if the package.json version doesn't exist on NPM.

I would like to explore using something like [Changesets](https://github.com/changesets/changesets) in the future to manage releasing versions.

The current package versions are 2.0.0 so that the major version matches the supported major Policy Reporter version.

Part of #1 