### PR TITLE
fix(ci): setup .npmrc instead of env variable

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}


### PR DESCRIPTION
This PR adds the `.npmrc` file used to authenticate towards NPM. This file uses the NPM_TOKEN env variable