### PR TITLE
fix: publishConfig main and module file

### DIFF
--- a/plugins/policy-reporter-backend/package.json
+++ b/plugins/policy-reporter-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kyverno/backstage-plugin-policy-reporter-backend",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/policy-reporter-backend/package.json
+++ b/plugins/policy-reporter-backend/package.json
@@ -15,7 +15,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "main": "dist/index.esm.js",
+    "main": "dist/index.cjs.js",
     "types": "dist/index.d.ts"
   },
   "repository": {

--- a/plugins/policy-reporter-common/package.json
+++ b/plugins/policy-reporter-common/package.json
@@ -16,7 +16,8 @@
   },
   "publishConfig": {
     "access": "public",
-    "main": "dist/index.esm.js",
+    "main": "dist/index.cjs.js",
+    "module": "dist/index.esm.js",
     "types": "dist/index.d.ts"
   },
   "repository": {

--- a/plugins/policy-reporter-common/package.json
+++ b/plugins/policy-reporter-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kyverno/backstage-plugin-policy-reporter-common",
   "description": "Common functionalities for the policy-reporter plugin",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR fixes the backend package to use the correct `main` file in `publishConfig`. Also updates the common package `publishConfig`

Both backend and common package versions was also bumped 