### PR TITLE
docs(readme): add seperate readme for each plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,6 @@ The Backstage-policy-reporter-plugin integrates [Policy Reporter](https://kyvern
 
 ## Setup Backstage with policy-reporter plugin
 
-> [!NOTE]
-> It's currently not possible to integrate this with a Backstage instance since the packages aren't published yet.
-
 ### Step 1: Install packages
 
 From your backstage root directory, run the following commands:

--- a/plugins/policy-reporter-backend/README.md
+++ b/plugins/policy-reporter-backend/README.md
@@ -1,14 +1,27 @@
-# kyverno-policy-reports
+# backstage-policy-reporter-plugin-backend
 
-Welcome to the kyverno-policy-reports backend plugin!
+The Backend for the Policy Reporter plugin
 
-_This plugin was created through the Backstage CLI_
+This plugin integrates [Policy Reporter](https://kyverno.github.io/policy-reporter/) with Backstage to provide a clear and detailed view of Kyverno Policies applied to your entities
 
-## Getting started
+## Installation
 
-Your plugin has been added to the example app in this repository, meaning you'll be able to access it by running `yarn
-start` in the root directory, and then navigating to [/kyvernoPolicyReportsPlugin/health](http://localhost:7007/api/kyvernoPolicyReportsPlugin/health).
+From your backstage root directory, run the following commands:
 
-You can also serve the plugin in isolation by running `yarn start` in the plugin directory.
-This method of serving the plugin provides quicker iteration speed and a faster startup and hot reloads.
-It is only meant for local development, and the setup for it can be found inside the [/dev](/dev) directory.
+```bash
+yarn --cwd packages/backend add @kyverno/backstage-plugin-policy-reporter-backend
+```
+
+Then add the plugin to your backend in `packages/backend/src/index.ts`
+
+```diff
+
+const backend = createBackend();
+
+// ..
++backend.add(import('@kyverno/backstage-plugin-policy-reporter-backend'));
+// ..
+
+backend.start();
+
+```

--- a/plugins/policy-reporter-common/README.md
+++ b/plugins/policy-reporter-common/README.md
@@ -1,5 +1,9 @@
 # backstage-plugin-policy-reporter-common
 
-Welcome to the common package for the policy-reporter plugin!
+This package provides shared types and utilities for the policy-reporter plugin.
 
-_This plugin was created through the Backstage CLI_
+## Installation
+
+```bash
+yarn add @kyverno/backstage-plugin-policy-reporter-common
+```

--- a/plugins/policy-reporter/README.md
+++ b/plugins/policy-reporter/README.md
@@ -1,0 +1,100 @@
+# backstage-policy-reporter-plugin
+
+The Frontend for the Policy Reporter plugin
+
+This plugin integrates [Policy Reporter](https://kyverno.github.io/policy-reporter/) with Backstage to provide a clear and detailed view of Kyverno Policies applied to your entities
+
+The [Backend](https://www.npmjs.com/package/@kyverno/backstage-plugin-policy-reporter-backend?activeTab=readme) plugin is required for this plugin to work
+
+## Installation
+
+Add the plugin to your frontend app
+
+```bash
+yarn --cwd packages/app add @kyverno/backstage-plugin-policy-reporter
+```
+
+Add the **EntityKyvernoPoliciesContent** component to the Entity routes in `packages/app/src/components/catalog/EntityPage.tsx`
+
+```diff
+
++ import { EntityKyvernoPoliciesContent } from '@kyverno/backstage-plugin-policy-reporter';
+
+const serviceEntityPage = (
+
+  <EntityLayout>
+
+    // ...
+
++    <EntityLayout.Route path="/kyverno" title="kyverno policy">
++      <EntityKyvernoPoliciesContent />
++    </EntityLayout.Route>
+
+    // ..
+
+  </EntityLayout>
+)
+```
+
+## Configuration
+
+### Define Kubernetes Clusters
+
+In your Backstage instance, define your Kubernetes clusters using the `Resource` kind and `kubernetes-cluster` type. Add the `kyverno.io/endpoint` annotation with the URL to the Policy Reporter API for each cluster.
+
+```yaml
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: aks-dev
+  annotations:
+    # Add the Policy Reporter API endpoint as an annotation
+    kyverno.io/endpoint: http://kyverno.io/policy-reporter/api/
+spec:
+  type: kubernetes-cluster
+```
+
+### Annotate Services
+
+To show the policies on the service, add a dependency to the Kubernetes cluster resource in the `catalog-info.yaml` file of your service. Ensure that the necessary annotations are added as well. For more details, refer to the [How to annotate services](../../README.md#how-to-annotate-services) section.
+
+```yaml
+metadata:
+  annotations:
+    kyverno.io/namespace: default # Specify the namespace of the service
+    kyverno.io/kind: Deployment,Pod # Specify the kind(s) of the Kubernetes resource(s)
+    kyverno.io/resource-name: policy-reporter # Specify the name of the resource
+spec:
+  dependsOn:
+    # Add dependency to all environments the service is deployed to using the Resource entityRef
+    - resource:default/aks-dev
+    - resource:default/aks-tst
+    - resource:default/aks-qa
+    - resource:default/aks-prd
+```
+
+## Customization
+
+To configure the plugin to make the policy Chip a link to custom documentation, follow the steps below.
+
+To enable policy Chip links, the **EntityKyvernoPolicyReportsContent** component requires the **policyDocumentationUrl** prop to be set to the URL of the documentation.
+
+```typescript
+const serviceEntityPage = (
+  <EntityLayout>
+    // ...
+    <EntityLayout.Route path="/kyverno" title="kyverno policy">
+      <EntityKyvernoPoliciesContent policyDocumentationUrl="Your full URL link" />
+    </EntityLayout.Route>
+    // ..
+  </EntityLayout>
+);
+```
+
+The policy documentation file provided in the above step needs to follow a specific structure.
+
+All policies being used should have a header that matches the exact same name as the policy. Under this header, you can add information about the policy and provide a guide on how to solve it.
+
+The plugin will create a link using the following format: `<DocumentationUrl>#<PolicyName>`
+
+See the [example/policy-documentation.md](../../example/policy-documentation.md) file for an example of how this could look.


### PR DESCRIPTION
This pull request updates the `README.md` inside each plugin folder. This is what's displayed when viewing the packages on NPM.

