### PR TITLE
chore(kyverno): update filter for failing policies

### DIFF
--- a/plugins/policy-reporter/package.json
+++ b/plugins/policy-reporter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kyverno/backstage-plugin-policy-reporter",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/policy-reporter/src/components/EntityKyvernoPoliciesContent/EntityKyvernoPoliciesContent.tsx
+++ b/plugins/policy-reporter/src/components/EntityKyvernoPoliciesContent/EntityKyvernoPoliciesContent.tsx
@@ -99,7 +99,7 @@ export const EntityKyvernoPoliciesContent = ({
               namespaces,
               sources: ['kyverno'],
               kinds,
-              status: ['fail'],
+              status: ['fail', 'warn', 'error'],
               search: resourceName,
             }}
             title="Failing Policy Results"


### PR DESCRIPTION
This PR updates the failing policies filter used in the `EntityKyvernoPoliciesContent` component to include both warning and error status reports.