### PR TITLE
feat: add component for viewing policies from custom sources

### DIFF
--- a/.changeset/ripe-seas-taste.md
+++ b/.changeset/ripe-seas-taste.md
@@ -1,0 +1,5 @@
+---
+'@kyverno/backstage-plugin-policy-reporter': minor
+---
+
+Add `EntityCustomPoliciesContent` component that can be used to view policies from custom sources

--- a/README.md
+++ b/README.md
@@ -41,7 +41,15 @@ yarn --cwd packages/backend add @kyverno/backstage-plugin-policy-reporter-backen
 
 ### Step 2: Add the route
 
-Add the **EntityKyvernoPoliciesContent** component to the Entity routes in `packages/app/src/components/catalog/EntityPage.tsx`
+Add the desired policy-reporter component(s) to your Entity routes in `packages/app/src/components/catalog/EntityPage.tsx`
+Choose from the available components:
+
+- [EntityKyvernoPoliciesContent](/docs/component-setup.md#entitykyvernopoliciescontent) - Displays kyverno policies for an entity using the `kyverno` source
+- [EntityCustomPoliciesContent](/docs/component-setup.md#entitycustompoliciescontent) - Displays policy reports from a custom source
+
+For detailed setup instructions including screenshots, see the [Component Setup Guide](/docs/component-setup.md).
+
+#### EntityKyvernoPoliciesContent example
 
 ```diff
 

--- a/docs/component-setup.md
+++ b/docs/component-setup.md
@@ -1,0 +1,79 @@
+# Component Setup Guide
+
+<details>
+  <summary><strong>EntityKyvernoPoliciesContent</strong> - Displays kyverno policies for an entity</summary>
+
+## EntityKyvernoPoliciesContent
+
+The `EntityKyvernoPoliciesContent` component displays kyverno policies for an entity using the `kyverno` source
+
+### Screenshot
+
+![EntityKyvernoPoliciesContent](./assets/screenshot.PNG)
+
+### Setup Steps
+
+Add the `EntityKyvernoPoliciesContent` component to the Entity routes in `packages/app/src/components/catalog/EntityPage.tsx`
+
+```diff
++ import { EntityKyvernoPoliciesContent } from '@kyverno/backstage-plugin-policy-reporter';
+
+const serviceEntityPage = (
+  <EntityLayout>
+    {/* ... existing routes ... */}
++    <EntityLayout.Route path="/kyverno" title="kyverno policy">
++      <EntityKyvernoPoliciesContent />
++    </EntityLayout.Route>
+    {/* ... */}
+  </EntityLayout>
+)
+```
+
+### Configuration Options
+
+| Prop                        | Type   | Default   | Description                                                                                                                      |
+| --------------------------- | ------ | --------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| annotationsDocumentationUrl | string | undefined | Optional URL used for the READ MORE button when annotations are missing                                                          |
+| policyDocumentationUrl      | string | undefined | Optional URL used to generate links to policy documentation. [More information](/README.md#optional-custom-policy-documentation) |
+
+</details>
+
+<details>
+  <summary><strong>EntityCustomPoliciesContent</strong> - Displays policy reports for an entity with a custom source</summary>
+
+## EntityCustomPoliciesContent
+
+The `EntityCustomPoliciesContent` component displays policy reports from a custom source.
+
+### Screenshot
+
+![EntityCustomPoliciesContent](./assets/screenshot.PNG)
+
+### Setup Steps
+
+Add the `EntityCustomPoliciesContent` component to the Entity routes in `packages/app/src/components/catalog/EntityPage.tsx`
+
+```diff
++ import { EntityCustomPoliciesContent } from '@kyverno/backstage-plugin-policy-reporter';
+
+const serviceEntityPage = (
+  <EntityLayout>
+    {/* ... existing routes ... */}
++    <EntityLayout.Route path="/kyverno" title="kyverno policy">
++      <EntityCustomPoliciesContent title="Kyverno Policy Reports" sources={['kyverno']} />
++    </EntityLayout.Route>
+    {/* ... */}
+  </EntityLayout>
+)
+```
+
+### Configuration Options
+
+| Prop                        | Type     | Default   | Description                                                                                                                      |
+| --------------------------- | -------- | --------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| title                       | string   | undefined | Required Title to use for the content page                                                                                       |
+| sources                     | string[] | undefined | Required Array of all the sources to component should show policies for                                                          |
+| annotationsDocumentationUrl | string   | undefined | Optional URL used for the READ MORE button when annotations are missing                                                          |
+| policyDocumentationUrl      | string   | undefined | Optional URL used to generate links to policy documentation. [More information](/README.md#optional-custom-policy-documentation) |
+
+</details>

--- a/docs/component-setup.md
+++ b/docs/component-setup.md
@@ -45,6 +45,10 @@ const serviceEntityPage = (
 
 The `EntityCustomPoliciesContent` component displays policy reports from a custom source.
 
+This plugin aims to provide specialized components for different policy sources. If you need a component for a specific policy source that isn't currently available, please [open an issue](https://github.com/kyverno/backstage-policy-reporter-plugin/issues/new) with details about your use case.
+
+New source-specific components are being developed based on user needs.
+
 ### Screenshot
 
 ![EntityCustomPoliciesContent](./assets/screenshot.PNG)

--- a/plugins/policy-reporter/README.md
+++ b/plugins/policy-reporter/README.md
@@ -14,7 +14,15 @@ Add the plugin to your frontend app
 yarn --cwd packages/app add @kyverno/backstage-plugin-policy-reporter
 ```
 
-Add the **EntityKyvernoPoliciesContent** component to the Entity routes in `packages/app/src/components/catalog/EntityPage.tsx`
+Add the desired policy-reporter component(s) to your Entity routes in `packages/app/src/components/catalog/EntityPage.tsx`
+Choose from the available components:
+
+- [EntityKyvernoPoliciesContent](/docs/component-setup.md#entitykyvernopoliciescontent) - Displays kyverno policies for an entity using the `kyverno` source
+- [EntityCustomPoliciesContent](/docs/component-setup.md#entitycustompoliciescontent) - Displays policy reports from a custom source
+
+For detailed setup instructions including screenshots, see the [Component Setup Guide](/docs/component-setup.md).
+
+#### EntityKyvernoPoliciesContent example
 
 ```diff
 

--- a/plugins/policy-reporter/dev/index.tsx
+++ b/plugins/policy-reporter/dev/index.tsx
@@ -3,6 +3,7 @@ import { createDevApp } from '@backstage/dev-utils';
 import {
   policyReporterPlugin,
   EntityKyvernoPoliciesContent,
+  EntityCustomPoliciesContent,
 } from '../src/plugin';
 import { EntityProvider, catalogApiRef } from '@backstage/plugin-catalog-react';
 import { Entity } from '@backstage/catalog-model';
@@ -93,8 +94,8 @@ createDevApp()
   )
   .registerPlugin(policyReporterPlugin)
   .addPage({
-    path: '/catalog-example',
-    title: 'Example one',
+    path: '/kyverno',
+    title: 'Kyverno Valid',
     // Wrap the plugin in entity mock
     element: (
       <EntityProvider entity={mockEntity}>
@@ -106,8 +107,8 @@ createDevApp()
     ),
   })
   .addPage({
-    path: '/example-2',
-    title: 'Missing annotations',
+    path: '/kyverno/annotations',
+    title: 'Kyverno Missing annotations',
     // Wrap the plugin in entity mock
     element: (
       <EntityProvider entity={mockEntityNoAnnotations}>
@@ -119,12 +120,57 @@ createDevApp()
     ),
   })
   .addPage({
-    path: '/example-3',
-    title: 'Missing environments',
+    path: '/kyverno/environments',
+    title: 'Kyverno Missing environments',
     // Wrap the plugin in entity mock
     element: (
       <EntityProvider entity={mockEntityNoEnvironments}>
         <EntityKyvernoPoliciesContent
+          annotationsDocumentationUrl="https://github.com/"
+          policyDocumentationUrl="https://github.com/"
+        />
+      </EntityProvider>
+    ),
+  })
+  .addPage({
+    path: '/custom',
+    title: 'Custom Valid',
+    // Wrap the plugin in entity mock
+    element: (
+      <EntityProvider entity={mockEntity}>
+        <EntityCustomPoliciesContent
+          title="Custom Source Policy Reports"
+          sources={['kyverno']}
+          annotationsDocumentationUrl="https://github.com/"
+          policyDocumentationUrl="https://github.com/"
+        />
+      </EntityProvider>
+    ),
+  })
+  .addPage({
+    path: '/custom/environments',
+    title: 'Custom Missing environments',
+    // Wrap the plugin in entity mock
+    element: (
+      <EntityProvider entity={mockEntityNoEnvironments}>
+        <EntityCustomPoliciesContent
+          title="Custom Source Policy Reports"
+          sources={['kyverno']}
+          annotationsDocumentationUrl="https://github.com/"
+          policyDocumentationUrl="https://github.com/"
+        />
+      </EntityProvider>
+    ),
+  })
+  .addPage({
+    path: '/custom/annotations',
+    title: 'Custom Missing annotations',
+    // Wrap the plugin in entity mock
+    element: (
+      <EntityProvider entity={mockEntityNoAnnotations}>
+        <EntityCustomPoliciesContent
+          title="Custom Source Policy Reports"
+          sources={['kyverno']}
           annotationsDocumentationUrl="https://github.com/"
           policyDocumentationUrl="https://github.com/"
         />

--- a/plugins/policy-reporter/src/components/EntityCustomPoliciesContent/EntityCustomPoliciesContent.test.tsx
+++ b/plugins/policy-reporter/src/components/EntityCustomPoliciesContent/EntityCustomPoliciesContent.test.tsx
@@ -1,0 +1,127 @@
+import React from 'react';
+import { policyReporterApiRef } from '../../api';
+import { Entity } from '@backstage/catalog-model';
+import { TestApiProvider, renderInTestApp } from '@backstage/test-utils';
+import { EntityCustomPoliciesContent } from './EntityCustomPoliciesContent';
+import { EntityProvider, catalogApiRef } from '@backstage/plugin-catalog-react';
+
+const mockPolicyReportApiRef = {
+  namespacedResults: jest.fn(),
+};
+
+const mockCatalogApiRef = {
+  getEntitiesByRefs: jest.fn(),
+};
+
+const mockEntity: Entity = {
+  apiVersion: 'backstage.io/v1alpha1',
+  kind: 'Component',
+  metadata: {
+    name: 'policy-reporter',
+    description: 'Policy-reporter',
+    annotations: {
+      'kyverno.io/namespace': 'default',
+      'kyverno.io/kind': 'deployment',
+      'kyverno.io/resource-name': 'policy-reporter',
+    },
+  },
+  spec: {
+    type: 'website',
+    owner: 'user:guest',
+    lifecycle: 'production',
+    dependsOn: ['resource:default/dev'],
+  },
+};
+
+const title = 'Trivy Policy Reports';
+
+describe('EntityCustomPoliciesContent component', () => {
+  it('should render Missing Annotation when annotations are missing', async () => {
+    // Arrange
+    // Modify the mock entity to not include annotations
+    const mockEntityNoAnnotations: Entity = {
+      ...mockEntity,
+      metadata: {
+        ...mockEntity.metadata,
+        annotations: undefined,
+      },
+    };
+
+    // Act
+    const extension = await renderInTestApp(
+      <TestApiProvider
+        apis={[
+          [policyReporterApiRef, mockPolicyReportApiRef as any],
+          [catalogApiRef, mockCatalogApiRef],
+        ]}
+      >
+        <EntityProvider entity={mockEntityNoAnnotations}>
+          <EntityCustomPoliciesContent title={title} sources={['trivy']} />
+        </EntityProvider>
+        ,
+      </TestApiProvider>,
+    );
+
+    // Assert
+    expect(extension.getAllByText('Missing Annotation')).toBeTruthy();
+  });
+
+  it('should render Missing Environments when environment dependency is missing', async () => {
+    // Arrange
+    // Modify the mock entity to not include annotations
+    const mockEntityNoAnnotations: Entity = {
+      ...mockEntity,
+      spec: {
+        ...mockEntity.spec,
+        dependsOn: undefined,
+      },
+    };
+
+    // Act
+    const extension = await renderInTestApp(
+      <TestApiProvider
+        apis={[
+          [policyReporterApiRef, mockPolicyReportApiRef as any],
+          [catalogApiRef, mockCatalogApiRef],
+        ]}
+      >
+        <EntityProvider entity={mockEntityNoAnnotations}>
+          <EntityCustomPoliciesContent title={title} sources={['trivy']} />
+        </EntityProvider>
+        ,
+      </TestApiProvider>,
+    );
+
+    // Assert
+    expect(
+      extension.getAllByText('Missing Valid Environment Dependency'),
+    ).toBeTruthy();
+  });
+
+  it('should render policyReportsTable if annotations and environments are valid', async () => {
+    // Arrange
+    mockCatalogApiRef.getEntitiesByRefs.mockImplementationOnce(() => {
+      return Promise.resolve({ items: [{ metadata: { name: 'dev' } }] });
+    });
+
+    // Act
+    const extension = await renderInTestApp(
+      <TestApiProvider
+        apis={[
+          [policyReporterApiRef, mockPolicyReportApiRef as any],
+          [catalogApiRef, mockCatalogApiRef],
+        ]}
+      >
+        <EntityProvider entity={mockEntity}>
+          <EntityCustomPoliciesContent title={title} sources={['trivy']} />
+        </EntityProvider>
+      </TestApiProvider>,
+    );
+
+    // Assert
+    expect(extension.getByText(title)).toBeTruthy();
+    expect(extension.getByText('Failing Policy Results')).toBeTruthy();
+    expect(extension.getByText('Passing Policy Results')).toBeTruthy();
+    expect(extension.getByText('Skipped Policy Results')).toBeTruthy();
+  });
+});

--- a/plugins/policy-reporter/src/components/EntityCustomPoliciesContent/EntityCustomPoliciesContent.tsx
+++ b/plugins/policy-reporter/src/components/EntityCustomPoliciesContent/EntityCustomPoliciesContent.tsx
@@ -1,0 +1,147 @@
+import {
+  Content,
+  ContentHeader,
+  Page,
+  Progress,
+} from '@backstage/core-components';
+import React from 'react';
+import {
+  MissingAnnotationEmptyState,
+  useEntity,
+} from '@backstage/plugin-catalog-react';
+import { Grid } from '@material-ui/core';
+import { PolicyReportsTable } from '../PolicyReportsTable';
+import { SelectEnvironment } from '../SelectEnvironment';
+import {
+  containsRequiredAnnotations,
+  annotationsRequired,
+} from '../../utils/annotations';
+import { MissingEnvironmentsEmptyState } from '../MissingEnvironmentsEmptyState';
+import { useEntityEnvironment } from '../../hooks/useEntityEnvironment';
+import {
+  KYVERNO_KIND_ANNOTATION,
+  KYVERNO_NAMESPACE_ANNOTATION,
+  KYVERNO_RESOURCE_NAME_ANNOTATION,
+} from '@kyverno/backstage-plugin-policy-reporter-common';
+
+type EntityCustomPoliciesContentProps = {
+  annotationsDocumentationUrl?: string;
+  policyDocumentationUrl?: string;
+  sources: string[];
+  title: string;
+};
+
+type PageContentProps = {
+  children: React.ReactNode;
+};
+
+const PageContent = ({ children }: PageContentProps) => (
+  <Page themeId="tool">
+    <Content>{children}</Content>
+  </Page>
+);
+
+export const EntityCustomPoliciesContent = ({
+  annotationsDocumentationUrl,
+  policyDocumentationUrl,
+  sources,
+  title,
+}: EntityCustomPoliciesContentProps) => {
+  const { entity } = useEntity();
+  const annotations = entity.metadata.annotations;
+
+  // Boolean variable to validate that entity have required annotations
+  const annotationsState: boolean = containsRequiredAnnotations(annotations);
+
+  const {
+    environments,
+    environmentsLoading,
+    setCurrentEnvironment,
+    currentEnvironment,
+  } = useEntityEnvironment(entity, annotationsState);
+
+  // Annotations missing
+  if (!annotationsState)
+    return (
+      <PageContent>
+        <MissingAnnotationEmptyState
+          readMoreUrl={annotationsDocumentationUrl}
+          annotation={annotationsRequired}
+        />
+      </PageContent>
+    );
+
+  // Fetching environments
+  if (environmentsLoading) return <Progress />;
+
+  // Environments missing
+  if (environments === undefined || !currentEnvironment)
+    return (
+      <PageContent>
+        <MissingEnvironmentsEmptyState entity={entity} />
+      </PageContent>
+    );
+
+  const namespaces = annotations![KYVERNO_NAMESPACE_ANNOTATION].split(',');
+  const kinds = annotations![KYVERNO_KIND_ANNOTATION].split(',');
+  const resourceName = annotations![KYVERNO_RESOURCE_NAME_ANNOTATION];
+
+  return (
+    <PageContent>
+      <ContentHeader title={title}>
+        <SelectEnvironment
+          environments={environments}
+          currentEnvironment={currentEnvironment}
+          setCurrentEnvironment={setCurrentEnvironment}
+        />
+      </ContentHeader>
+      <Grid container spacing={2}>
+        <Grid item xs={12}>
+          <PolicyReportsTable
+            currentEnvironment={currentEnvironment}
+            filter={{
+              namespaces,
+              sources,
+              kinds,
+              status: ['fail', 'warn', 'error'],
+              search: resourceName,
+            }}
+            title="Failing Policy Results"
+            emptyContentText="No failing policies"
+            policyDocumentationUrl={policyDocumentationUrl}
+          />
+        </Grid>
+        <Grid item xs={12}>
+          <PolicyReportsTable
+            currentEnvironment={currentEnvironment}
+            filter={{
+              namespaces,
+              sources,
+              kinds,
+              status: ['pass'],
+              search: resourceName,
+            }}
+            title="Passing Policy Results"
+            emptyContentText="No passing policies"
+            policyDocumentationUrl={policyDocumentationUrl}
+          />
+        </Grid>
+        <Grid item xs={12}>
+          <PolicyReportsTable
+            currentEnvironment={currentEnvironment}
+            filter={{
+              namespaces,
+              sources,
+              kinds,
+              status: ['skip'],
+              search: resourceName,
+            }}
+            title="Skipped Policy Results"
+            emptyContentText="No skipped policies"
+            policyDocumentationUrl={policyDocumentationUrl}
+          />
+        </Grid>
+      </Grid>
+    </PageContent>
+  );
+};

--- a/plugins/policy-reporter/src/components/EntityCustomPoliciesContent/index.ts
+++ b/plugins/policy-reporter/src/components/EntityCustomPoliciesContent/index.ts
@@ -1,0 +1,1 @@
+export { EntityCustomPoliciesContent } from './EntityCustomPoliciesContent';

--- a/plugins/policy-reporter/src/components/EntityKyvernoPoliciesContent/EntityKyvernoPoliciesContent.test.tsx
+++ b/plugins/policy-reporter/src/components/EntityKyvernoPoliciesContent/EntityKyvernoPoliciesContent.test.tsx
@@ -96,7 +96,7 @@ describe('EntityKyvernoPolicyReportsContent component', () => {
     ).toBeTruthy();
   });
 
-  it('should render KyvernoPolicyReportsTable if annotations and environments are valid', async () => {
+  it('should render PolicyReportsTable if annotations and environments are valid', async () => {
     // Arrange
     mockCatalogApiRef.getEntitiesByRefs.mockImplementationOnce(() => {
       return Promise.resolve({ items: [{ metadata: { name: 'dev' } }] });

--- a/plugins/policy-reporter/src/index.ts
+++ b/plugins/policy-reporter/src/index.ts
@@ -1,1 +1,5 @@
-export { policyReporterPlugin, EntityKyvernoPoliciesContent } from './plugin';
+export {
+  policyReporterPlugin,
+  EntityKyvernoPoliciesContent,
+  EntityCustomPoliciesContent,
+} from './plugin';

--- a/plugins/policy-reporter/src/plugin.ts
+++ b/plugins/policy-reporter/src/plugin.ts
@@ -32,3 +32,14 @@ export const EntityKyvernoPoliciesContent = policyReporterPlugin.provide(
     mountPoint: rootRouteRef,
   }),
 );
+
+export const EntityCustomPoliciesContent = policyReporterPlugin.provide(
+  createRoutableExtension({
+    name: 'EntityCustomPoliciesContent',
+    component: () =>
+      import('./components/EntityCustomPoliciesContent').then(
+        m => m.EntityCustomPoliciesContent,
+      ),
+    mountPoint: rootRouteRef,
+  }),
+);


### PR DESCRIPTION
This PR adds the `EntityCustomPoliciesContent` component that can be used to view policies from custom sources. Documentation has also been updated with information about both components.

The local dev environment has been updated to include 3 examples using the new custom policy component.

Part of #3 