### PR TITLE
ci(release): use yarn to publish package instead of changeset

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,12 +2,11 @@ name: ci
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, closed]
-  workflow_dispatch:
+    branches:
+      - main
 
 jobs:
   test_and_build:
-    if: github.event.pull_request.merged == false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -30,40 +29,3 @@ jobs:
           yarn test:all:no-watch
           yarn tsc
           yarn build:all
-
-  publish:
-    if: github.event.pull_request.merged == true
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-
-      - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
-        with:
-          node-version: '20'
-
-      - name: yarn install
-        uses: backstage/actions/yarn-install@b3c1841fd69e1658ac631afafd0fb140a2309024 # v0.6.17
-        with:
-          cache-prefix: ${{ runner.os }}-v20
-
-      - name: Build
-        run: |
-          yarn tsc
-          yarn build:all
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-      - name: Publish
-        id: changesets
-        uses: changesets/action@e0145edc7d9d8679003495b11f87bd8ef63c0cba
-        with:
-          version: node .github/changeset-version.cjs
-          publish: yarn changeset publish
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,50 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org' # Needed for auth
+
+      - name: yarn install
+        uses: backstage/actions/yarn-install@b3c1841fd69e1658ac631afafd0fb140a2309024 # v0.6.17
+        with:
+          cache-prefix: ${{ runner.os }}-v20
+
+      - name: Compile TypeScript
+        run: yarn tsc
+
+      - name: Build all packages
+        run: yarn build:all
+
+      - name: Setup yarn auth
+        run: yarn config set -H 'npmAuthToken' "${{secrets.NPM_TOKEN}}"
+
+      - name: Publish
+        id: changesets
+        uses: changesets/action@e0145edc7d9d8679003495b11f87bd8ef63c0cba
+        with:
+          version: node .github/changeset-version.cjs
+          publish: yarn run publish
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "lint:all": "backstage-cli repo lint",
     "prettier:check": "prettier --check .",
     "new": "backstage-cli new --scope internal",
-    "prepare": "husky"
+    "prepare": "husky",
+    "publish": "yarn workspaces foreach --all --no-private --topological --verbose npm publish --tolerate-republish"
   },
   "workspaces": {
     "packages": [


### PR DESCRIPTION
This PR updates the changeset action to use a new Yarn script for publishing packages. It leverages `yarn npm publish` to publish the packages, enabling compatibility with the Backstage Yarn plugin.

Part of #48