### PR TITLE
ci(release): use yarn changeset tag after publish step

### DIFF
--- a/.changeset/warm-shoes-carry.md
+++ b/.changeset/warm-shoes-carry.md
@@ -1,0 +1,7 @@
+---
+'@kyverno/backstage-plugin-policy-reporter': patch
+'@kyverno/backstage-plugin-policy-reporter-backend': patch
+'@kyverno/backstage-plugin-policy-reporter-common': patch
+---
+
+New release to validate updated publishing workflow

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,7 +43,7 @@ jobs:
         uses: changesets/action@e0145edc7d9d8679003495b11f87bd8ef63c0cba
         with:
           version: node .github/changeset-version.cjs
-          publish: yarn run publish
+          publish: yarn run publish && yarn changeset tag
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR updates the changeset action to use `yarn changeset tag` after publishing to create new Git tags.
