### PR TITLE
ci: release

### DIFF
--- a/.changeset/heavy-pots-deny.md
+++ b/.changeset/heavy-pots-deny.md
@@ -1,0 +1,7 @@
+---
+'@kyverno/backstage-plugin-policy-reporter-backend': patch
+'@kyverno/backstage-plugin-policy-reporter-common': patch
+'@kyverno/backstage-plugin-policy-reporter': patch
+---
+
+New release to validate updated publishing workflow

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "prettier:check": "prettier --check .",
     "new": "backstage-cli new --scope internal",
     "prepare": "husky",
-    "publish": "yarn workspaces foreach --all --no-private --topological --verbose npm publish --tolerate-republish"
+    "publish": "yarn workspaces foreach --all --no-private --topological --verbose npm publish --tolerate-republish && yarn changeset tag"
   },
   "workspaces": {
     "packages": [

--- a/plugins/policy-reporter-backend/CHANGELOG.md
+++ b/plugins/policy-reporter-backend/CHANGELOG.md
@@ -1,13 +1,5 @@
 # @kyverno/backstage-plugin-policy-reporter-backend
 
-## 2.1.3
-
-### Patch Changes
-
-- 1cbf09a: New release to validate updated publishing workflow
-- Updated dependencies [1cbf09a]
-  - @kyverno/backstage-plugin-policy-reporter-common@2.0.6
-
 ## 2.1.2
 
 ### Patch Changes

--- a/plugins/policy-reporter-backend/package.json
+++ b/plugins/policy-reporter-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kyverno/backstage-plugin-policy-reporter-backend",
-  "version": "2.1.3",
+  "version": "2.1.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -42,7 +42,7 @@
     "@backstage/backend-plugin-api": "^1.3.0",
     "@backstage/config": "^1.3.2",
     "@backstage/plugin-catalog-node": "^1.16.3",
-    "@kyverno/backstage-plugin-policy-reporter-common": "2.0.6",
+    "@kyverno/backstage-plugin-policy-reporter-common": "2.0.5",
     "@types/express": "*",
     "express": "^4.17.1",
     "express-promise-router": "^4.1.0",

--- a/plugins/policy-reporter-common/CHANGELOG.md
+++ b/plugins/policy-reporter-common/CHANGELOG.md
@@ -1,11 +1,5 @@
 # @kyverno/backstage-plugin-policy-reporter-common
 
-## 2.0.6
-
-### Patch Changes
-
-- 1cbf09a: New release to validate updated publishing workflow
-
 ## 2.0.5
 
 ### Patch Changes

--- a/plugins/policy-reporter-common/package.json
+++ b/plugins/policy-reporter-common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kyverno/backstage-plugin-policy-reporter-common",
   "description": "Common functionalities for the policy-reporter plugin",
-  "version": "2.0.6",
+  "version": "2.0.5",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/policy-reporter/CHANGELOG.md
+++ b/plugins/policy-reporter/CHANGELOG.md
@@ -1,13 +1,5 @@
 # @kyverno/backstage-plugin-policy-reporter
 
-## 2.2.3
-
-### Patch Changes
-
-- 1cbf09a: New release to validate updated publishing workflow
-- Updated dependencies [1cbf09a]
-  - @kyverno/backstage-plugin-policy-reporter-common@2.0.6
-
 ## 2.2.2
 
 ### Patch Changes

--- a/plugins/policy-reporter/package.json
+++ b/plugins/policy-reporter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kyverno/backstage-plugin-policy-reporter",
-  "version": "2.2.3",
+  "version": "2.2.2",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -45,7 +45,7 @@
     "@backstage/core-plugin-api": "^1.10.6",
     "@backstage/plugin-catalog-react": "^1.17.0",
     "@backstage/theme": "^0.6.5",
-    "@kyverno/backstage-plugin-policy-reporter-common": "2.0.6",
+    "@kyverno/backstage-plugin-policy-reporter-common": "2.0.5",
     "@material-ui/core": "^4.9.13",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "4.0.0-alpha.61",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5922,7 +5922,7 @@ __metadata:
     "@backstage/plugin-auth-backend-module-guest-provider": "npm:^0.2.7"
     "@backstage/plugin-catalog-backend": "npm:^1.32.1"
     "@backstage/plugin-catalog-node": "npm:^1.16.3"
-    "@kyverno/backstage-plugin-policy-reporter-common": "npm:2.0.6"
+    "@kyverno/backstage-plugin-policy-reporter-common": "npm:2.0.5"
     "@types/express": "npm:*"
     "@types/supertest": "npm:^2.0.12"
     better-sqlite3: "npm:^9.0.0"
@@ -5935,7 +5935,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@kyverno/backstage-plugin-policy-reporter-common@npm:2.0.6, @kyverno/backstage-plugin-policy-reporter-common@workspace:plugins/policy-reporter-common":
+"@kyverno/backstage-plugin-policy-reporter-common@npm:2.0.5, @kyverno/backstage-plugin-policy-reporter-common@workspace:plugins/policy-reporter-common":
   version: 0.0.0-use.local
   resolution: "@kyverno/backstage-plugin-policy-reporter-common@workspace:plugins/policy-reporter-common"
   dependencies:
@@ -5957,7 +5957,7 @@ __metadata:
     "@backstage/plugin-catalog-react": "npm:^1.17.0"
     "@backstage/test-utils": "npm:^1.7.7"
     "@backstage/theme": "npm:^0.6.5"
-    "@kyverno/backstage-plugin-policy-reporter-common": "npm:2.0.6"
+    "@kyverno/backstage-plugin-policy-reporter-common": "npm:2.0.5"
     "@material-ui/core": "npm:^4.9.13"
     "@material-ui/icons": "npm:^4.9.1"
     "@material-ui/lab": "npm:4.0.0-alpha.61"


### PR DESCRIPTION
This PR updates the publish script to run `yarn changeset tag` after releasing.

I have reverted the recent "Version Packages" PR that failed to release. This will attempt to publish the packages again with the same version that previously failed.
