### PR TITLE
chore(changeset): ignore app and backend

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,5 @@
   "access": "public",
   "baseBranch": "origin/main",
   "updateInternalDependencies": "patch",
-  "ignore": []
+  "ignore": ["app", "backend"]
 }


### PR DESCRIPTION
This PR updates the changeset config to ignore `app` and `backend` packages.