### PR TITLE
chore: add policy report page to example app

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -39,11 +39,11 @@
     "@material-ui/core": "^4.12.2",
     "@material-ui/icons": "^4.9.1",
     "history": "^5.0.0",
-    "react": "^18.0.2",
+    "react": "^18.3.1",
     "react-dom": "^18.0.2",
-    "react-router": "^6.3.0",
-    "react-router-dom": "^6.3.0",
-    "react-use": "^17.2.4"
+    "react-router": "^6.30.1",
+    "react-router-dom": "^6.30.1",
+    "react-use": "^17.6.0"
   },
   "devDependencies": {
     "@backstage/test-utils": "backstage:^",

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -20,6 +20,7 @@ import { AppRouter, FlatRoutes } from '@backstage/core-app-api';
 import { CatalogGraphPage } from '@backstage/plugin-catalog-graph';
 import { RequirePermission } from '@backstage/plugin-permission-react';
 import { catalogEntityCreatePermission } from '@backstage/plugin-catalog-common/alpha';
+import { PolicyReporterPage } from '@kyverno/backstage-plugin-policy-reporter';
 
 const app = createApp({
   apis,
@@ -43,15 +44,7 @@ const routes = (
     >
       {entityPage}
     </Route>
-    <Route path="/api-docs" element={<ApiExplorerPage />} />
-    <Route
-      path="/catalog-import"
-      element={
-        <RequirePermission permission={catalogEntityCreatePermission}>
-          <CatalogImportPage />
-        </RequirePermission>
-      }
-    />
+    <Route path="/kyverno" element={<PolicyReporterPage />} />
     <Route path="/settings" element={<UserSettingsPage />} />
     <Route path="/catalog-graph" element={<CatalogGraphPage />} />
   </FlatRoutes>

--- a/packages/app/src/components/Root/Root.tsx
+++ b/packages/app/src/components/Root/Root.tsx
@@ -1,5 +1,4 @@
 import { PropsWithChildren } from 'react';
-import HomeIcon from '@material-ui/icons/Home';
 import {
   Settings as SidebarSettings,
   UserSettingsSignInAvatar,
@@ -12,7 +11,9 @@ import {
   SidebarPage,
   SidebarSpace,
 } from '@backstage/core-components';
+import HomeIcon from '@material-ui/icons/Home';
 import MenuIcon from '@material-ui/icons/Menu';
+import AssessmentIcon from '@material-ui/icons/Assessment';
 
 export const Root = ({ children }: PropsWithChildren<{}>) => (
   <SidebarPage>
@@ -23,6 +24,11 @@ export const Root = ({ children }: PropsWithChildren<{}>) => (
         <SidebarItem icon={HomeIcon} to="catalog" text="Home" />
         {/* End global nav */}
         <SidebarDivider />
+        <SidebarItem
+          icon={AssessmentIcon}
+          to="kyverno"
+          text="Policy Reporter"
+        />
       </SidebarGroup>
       <SidebarSpace />
       <SidebarDivider />

--- a/yarn.lock
+++ b/yarn.lock
@@ -8797,13 +8797,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@remix-run/router@npm:1.16.1":
-  version: 1.16.1
-  resolution: "@remix-run/router@npm:1.16.1"
-  checksum: 10c0/5f1b0aef4924830eeab9c86dcaa5af8157066e5de65b449e7fdf406532b2384828a46a447c31b0735fd713a06938dd88bfd4e566d9989be70c770457dda16c92
-  languageName: node
-  linkType: hard
-
 "@remix-run/router@npm:1.23.0":
   version: 1.23.0
   resolution: "@remix-run/router@npm:1.23.0"
@@ -13058,11 +13051,11 @@ __metadata:
     "@types/react-dom": "npm:*"
     cross-env: "npm:^7.0.0"
     history: "npm:^5.0.0"
-    react: "npm:^18.0.2"
+    react: "npm:^18.3.1"
     react-dom: "npm:^18.0.2"
-    react-router: "npm:^6.3.0"
-    react-router-dom: "npm:^6.3.0"
-    react-use: "npm:^17.2.4"
+    react-router: "npm:^6.30.1"
+    react-router-dom: "npm:^6.30.1"
+    react-use: "npm:^17.6.0"
   languageName: unknown
   linkType: soft
 
@@ -29020,19 +29013,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-router-dom@npm:^6.3.0":
-  version: 6.23.1
-  resolution: "react-router-dom@npm:6.23.1"
-  dependencies:
-    "@remix-run/router": "npm:1.16.1"
-    react-router: "npm:6.23.1"
-  peerDependencies:
-    react: ">=16.8"
-    react-dom: ">=16.8"
-  checksum: 10c0/01b954d7d0ff4c53bb2edbc816458f3fad1ce9ee49a4dfdc5c866065c23026c9cce429b46b754cbaebb83b22cfe5f605bbf441acf515e3c377cbdf021b0bec4c
-  languageName: node
-  linkType: hard
-
 "react-router-dom@npm:^6.30.1":
   version: 6.30.1
   resolution: "react-router-dom@npm:6.30.1"
@@ -29046,18 +29026,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-router@npm:6.23.1":
-  version: 6.23.1
-  resolution: "react-router@npm:6.23.1"
-  dependencies:
-    "@remix-run/router": "npm:1.16.1"
-  peerDependencies:
-    react: ">=16.8"
-  checksum: 10c0/091949805745136350ab049b2a96281bf38742c9d3651019fb48ea79c5eafbfb0379f1d3e636602dd56b0ef278389e8fd25be983dc2c0ffd1103d06dfa8019f3
-  languageName: node
-  linkType: hard
-
-"react-router@npm:6.30.1, react-router@npm:^6.3.0":
+"react-router@npm:6.30.1, react-router@npm:^6.30.1":
   version: 6.30.1
   resolution: "react-router@npm:6.30.1"
   dependencies:
@@ -29234,7 +29203,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react@npm:^18.0.2, react@npm:^18.3.1":
+"react@npm:^18.3.1":
   version: 18.3.1
   resolution: "react@npm:18.3.1"
   dependencies:


### PR DESCRIPTION
This bumps `react-router`, etc. to avoid the following errors:

```
useLocation() may be used only in the context of a <Router> component.
```

See https://github.com/backstage/backstage/issues/15315 for more context.

Also some other cleanup of unneeded app routes.