### PR TITLE
feat: add PolicyReportsPage status and severity filter

### DIFF
--- a/.changeset/crazy-dingos-add.md
+++ b/.changeset/crazy-dingos-add.md
@@ -1,0 +1,5 @@
+---
+'@kyverno/backstage-plugin-policy-reporter': minor
+---
+
+Add Status and Severity filter to `PolicyReportsPage` component and updates the UI to now be 1 big table that by default show all failing policies

--- a/.changeset/true-seals-fall.md
+++ b/.changeset/true-seals-fall.md
@@ -1,0 +1,5 @@
+---
+'@kyverno/backstage-plugin-policy-reporter': patch
+---
+
+Update the `PolicyReportsPage` component's exported name to match the documentation. It was previously set to `PolicyReporterPage` by mistake and has now been corrected to `PolicyReportsPage`.

--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -20,7 +20,7 @@ import { AppRouter, FlatRoutes } from '@backstage/core-app-api';
 import { CatalogGraphPage } from '@backstage/plugin-catalog-graph';
 import { RequirePermission } from '@backstage/plugin-permission-react';
 import { catalogEntityCreatePermission } from '@backstage/plugin-catalog-common/alpha';
-import { PolicyReporterPage } from '@kyverno/backstage-plugin-policy-reporter';
+import { PolicyReportsPage } from '@kyverno/backstage-plugin-policy-reporter';
 
 const app = createApp({
   apis,
@@ -44,7 +44,7 @@ const routes = (
     >
       {entityPage}
     </Route>
-    <Route path="/kyverno" element={<PolicyReporterPage />} />
+    <Route path="/kyverno" element={<PolicyReportsPage />} />
     <Route path="/settings" element={<UserSettingsPage />} />
     <Route path="/catalog-graph" element={<CatalogGraphPage />} />
   </FlatRoutes>

--- a/plugins/policy-reporter/src/components/PolicyReportsPage/PolicyReportsPage.test.tsx
+++ b/plugins/policy-reporter/src/components/PolicyReportsPage/PolicyReportsPage.test.tsx
@@ -54,8 +54,6 @@ describe('EntityKyvernoPolicyReportsContent component', () => {
 
     // Assert
     expect(extension.getByText('Policy Reports')).toBeTruthy();
-    expect(extension.getByText('Failing Policy Results')).toBeTruthy();
-    expect(extension.getByText('Passing Policy Results')).toBeTruthy();
-    expect(extension.getByText('Skipped Policy Results')).toBeTruthy();
+    expect(extension.getByText('Policy Results')).toBeTruthy();
   });
 });

--- a/plugins/policy-reporter/src/components/PolicyReportsPage/PolicyReportsPage.tsx
+++ b/plugins/policy-reporter/src/components/PolicyReportsPage/PolicyReportsPage.tsx
@@ -10,8 +10,12 @@ import { SelectEnvironment } from '../SelectEnvironment';
 import { Grid } from '@material-ui/core';
 import { PolicyReportsTable } from '../PolicyReportsTable';
 import { useState } from 'react';
-import { Status } from '@kyverno/backstage-plugin-policy-reporter-common';
+import {
+  Severity,
+  Status,
+} from '@kyverno/backstage-plugin-policy-reporter-common';
 import { SelectStatus } from '../SelectStatus';
+import { SelectSeverity } from '../SelectSeverity';
 
 export interface PolicyReportsPageProps {
   title?: string;
@@ -32,6 +36,7 @@ export const PolicyReportsPage = ({
   } = useEnvironments();
 
   const [status, setStatus] = useState<Status[]>(['fail']);
+  const [severity, setSeverity] = useState<Severity[]>([]);
 
   // Fetching environments
   if (environmentsLoading) return <Progress />;
@@ -45,6 +50,10 @@ export const PolicyReportsPage = ({
       <Content>
         <ContentHeader>
           <SelectStatus currentStatus={status} setStatus={setStatus} />
+          <SelectSeverity
+            currentSeverity={severity}
+            setSeverity={setSeverity}
+          />
           <SelectEnvironment
             environments={environments}
             currentEnvironment={currentEnvironment}
@@ -57,6 +66,7 @@ export const PolicyReportsPage = ({
               currentEnvironment={currentEnvironment}
               filter={{
                 status: status,
+                severities: severity,
               }}
               title="Policy Results"
               emptyContentText="No policies found"

--- a/plugins/policy-reporter/src/components/PolicyReportsPage/PolicyReportsPage.tsx
+++ b/plugins/policy-reporter/src/components/PolicyReportsPage/PolicyReportsPage.tsx
@@ -9,6 +9,9 @@ import { useEnvironments } from '../../hooks/useEnvironments';
 import { SelectEnvironment } from '../SelectEnvironment';
 import { Grid } from '@material-ui/core';
 import { PolicyReportsTable } from '../PolicyReportsTable';
+import { useState } from 'react';
+import { Status } from '@kyverno/backstage-plugin-policy-reporter-common';
+import { SelectStatus } from '../SelectStatus';
 
 export interface PolicyReportsPageProps {
   title?: string;
@@ -28,6 +31,8 @@ export const PolicyReportsPage = ({
     currentEnvironment,
   } = useEnvironments();
 
+  const [status, setStatus] = useState<Status[]>(['fail']);
+
   // Fetching environments
   if (environmentsLoading) return <Progress />;
 
@@ -39,6 +44,7 @@ export const PolicyReportsPage = ({
       <Header title={title} subtitle={subtitle} />
       <Content>
         <ContentHeader>
+          <SelectStatus currentStatus={status} setStatus={setStatus} />
           <SelectEnvironment
             environments={environments}
             currentEnvironment={currentEnvironment}
@@ -50,33 +56,12 @@ export const PolicyReportsPage = ({
             <PolicyReportsTable
               currentEnvironment={currentEnvironment}
               filter={{
-                status: ['fail', 'warn', 'error'],
+                status: status,
               }}
-              title="Failing Policy Results"
-              emptyContentText="No failing policies"
+              title="Policy Results"
+              emptyContentText="No policies found"
               policyDocumentationUrl={policyDocumentationUrl}
-            />
-          </Grid>
-          <Grid item xs={12}>
-            <PolicyReportsTable
-              currentEnvironment={currentEnvironment}
-              filter={{
-                status: ['pass'],
-              }}
-              title="Passing Policy Results"
-              emptyContentText="No passing policies"
-              policyDocumentationUrl={policyDocumentationUrl}
-            />
-          </Grid>
-          <Grid item xs={12}>
-            <PolicyReportsTable
-              currentEnvironment={currentEnvironment}
-              filter={{
-                status: ['skip'],
-              }}
-              title="Skipped Policy Results"
-              emptyContentText="No skipped policies"
-              policyDocumentationUrl={policyDocumentationUrl}
+              pagination={{ offset: 25 }}
             />
           </Grid>
         </Grid>

--- a/plugins/policy-reporter/src/components/PolicyReportsTable/PolicyReportsTable.tsx
+++ b/plugins/policy-reporter/src/components/PolicyReportsTable/PolicyReportsTable.tsx
@@ -7,6 +7,7 @@ import { useMemo, useState } from 'react';
 import {
   Filter,
   ListResult,
+  Pagination,
 } from '@kyverno/backstage-plugin-policy-reporter-common';
 import { Drawer, makeStyles } from '@material-ui/core';
 import Chip from '@material-ui/core/Chip';
@@ -24,6 +25,8 @@ interface PolicyReportsTableProps {
   emptyContentText: string;
   policyDocumentationUrl?: string;
   enableSearch?: boolean;
+  pagination?: Partial<Pagination>;
+  pageSizeOptions?: number[];
 }
 
 export const PolicyReportsTable = ({
@@ -33,6 +36,8 @@ export const PolicyReportsTable = ({
   filter,
   policyDocumentationUrl,
   enableSearch,
+  pagination,
+  pageSizeOptions,
 }: PolicyReportsTableProps) => {
   const useStyles = makeStyles(theme => ({
     empty: {
@@ -119,10 +124,11 @@ export const PolicyReportsTable = ({
     policies,
     policiesError,
     currentPage,
+    currentOffset,
     setCurrentPage,
     setCurrentOffset,
     initialLoading,
-  } = usePaginatedPolicies(currentEnvironment, mergedFilter);
+  } = usePaginatedPolicies(currentEnvironment, mergedFilter, pagination);
 
   if (policiesError) return <ResponseErrorPanel error={policiesError} />;
 
@@ -152,6 +158,8 @@ export const PolicyReportsTable = ({
           sorting: true,
           padding: 'dense',
           search: enableSearch,
+          pageSize: currentOffset,
+          pageSizeOptions: pageSizeOptions,
         }}
         onRowClick={(
           event?: React.MouseEvent<Element, MouseEvent>,

--- a/plugins/policy-reporter/src/components/SelectSeverity/SelectSeverity.tsx
+++ b/plugins/policy-reporter/src/components/SelectSeverity/SelectSeverity.tsx
@@ -1,0 +1,70 @@
+import MenuItem from '@material-ui/core/MenuItem';
+import InputLabel from '@material-ui/core/InputLabel';
+import FormControl from '@material-ui/core/FormControl';
+import Select from '@material-ui/core/Select';
+import { Severity } from '@kyverno/backstage-plugin-policy-reporter-common';
+import { makeStyles } from '@material-ui/core/styles';
+import { Checkbox, ListItemText } from '@material-ui/core';
+
+// This could be moved into the common package if needed in multiple places
+const SEVERITY_VALUES: Severity[] = [
+  'unknown',
+  'low',
+  'medium',
+  'high',
+  'critical',
+  'info',
+];
+
+const useStyles = makeStyles({
+  formControl: {
+    margin: 8,
+    minWidth: 150,
+  },
+});
+
+export type SelectSeverityProps = {
+  currentSeverity: Severity[];
+  setSeverity: (Status: Severity[]) => void;
+};
+
+export const SelectSeverity = ({
+  currentSeverity: currentSeverity,
+  setSeverity: setSeverity,
+}: SelectSeverityProps) => {
+  const classes = useStyles();
+
+  const handleChange = (event: React.ChangeEvent<{ value: unknown }>) => {
+    setSeverity(event.target.value as Severity[]);
+  };
+
+  return (
+    <FormControl className={classes.formControl}>
+      <InputLabel id="select-severity-label" shrink>
+        Severity
+      </InputLabel>
+      <Select
+        labelId="select-severity-label"
+        id="select-severity"
+        multiple
+        displayEmpty
+        value={currentSeverity}
+        renderValue={selected => {
+          if ((selected as Severity[]).length === 0) {
+            return 'All';
+          }
+
+          return (selected as Severity[]).join(', ');
+        }}
+        onChange={handleChange}
+      >
+        {SEVERITY_VALUES.map(severity => (
+          <MenuItem key={severity} value={severity}>
+            <Checkbox checked={currentSeverity.includes(severity)} />
+            <ListItemText primary={severity} />
+          </MenuItem>
+        ))}
+      </Select>
+    </FormControl>
+  );
+};

--- a/plugins/policy-reporter/src/components/SelectSeverity/index.ts
+++ b/plugins/policy-reporter/src/components/SelectSeverity/index.ts
@@ -1,0 +1,1 @@
+export { SelectSeverity, type SelectSeverityProps } from './SelectSeverity';

--- a/plugins/policy-reporter/src/components/SelectStatus/SelectStatus.tsx
+++ b/plugins/policy-reporter/src/components/SelectStatus/SelectStatus.tsx
@@ -1,0 +1,70 @@
+import MenuItem from '@material-ui/core/MenuItem';
+import InputLabel from '@material-ui/core/InputLabel';
+import FormControl from '@material-ui/core/FormControl';
+import Select from '@material-ui/core/Select';
+import { Status } from '@kyverno/backstage-plugin-policy-reporter-common';
+import { makeStyles } from '@material-ui/core/styles';
+import { Checkbox, ListItemText } from '@material-ui/core';
+
+// This could be moved into the common package if needed in multiple places
+const STATUS_VALUES: Status[] = [
+  'fail',
+  'skip',
+  'pass',
+  'warn',
+  'error',
+  'summary',
+];
+
+const useStyles = makeStyles({
+  formControl: {
+    margin: 8,
+    minWidth: 150,
+  },
+});
+
+export type SelectStatusProps = {
+  currentStatus: Status[];
+  setStatus: (Status: Status[]) => void;
+};
+
+export const SelectStatus = ({
+  currentStatus,
+  setStatus,
+}: SelectStatusProps) => {
+  const classes = useStyles();
+
+  const handleChange = (event: React.ChangeEvent<{ value: unknown }>) => {
+    setStatus(event.target.value as Status[]);
+  };
+
+  return (
+    <FormControl className={classes.formControl}>
+      <InputLabel id="select-status-label" shrink>
+        Status
+      </InputLabel>
+      <Select
+        labelId="select-status-label"
+        id="select-status"
+        multiple
+        displayEmpty
+        value={currentStatus}
+        renderValue={selected => {
+          if ((selected as Status[]).length === 0) {
+            return 'All';
+          }
+
+          return (selected as Status[]).join(', ');
+        }}
+        onChange={handleChange}
+      >
+        {STATUS_VALUES.map(status => (
+          <MenuItem key={status} value={status}>
+            <Checkbox checked={currentStatus.includes(status)} />
+            <ListItemText primary={status} />
+          </MenuItem>
+        ))}
+      </Select>
+    </FormControl>
+  );
+};

--- a/plugins/policy-reporter/src/components/SelectStatus/index.ts
+++ b/plugins/policy-reporter/src/components/SelectStatus/index.ts
@@ -1,0 +1,1 @@
+export { SelectStatus } from './SelectStatus';

--- a/plugins/policy-reporter/src/components/SelectStatus/index.ts
+++ b/plugins/policy-reporter/src/components/SelectStatus/index.ts
@@ -1,1 +1,1 @@
-export { SelectStatus } from './SelectStatus';
+export { SelectStatus, type SelectStatusProps } from './SelectStatus';

--- a/plugins/policy-reporter/src/hooks/usePaginatedPolicies.ts
+++ b/plugins/policy-reporter/src/hooks/usePaginatedPolicies.ts
@@ -1,5 +1,8 @@
 import { useAsync } from 'react-use';
-import { Environment } from '@kyverno/backstage-plugin-policy-reporter-common';
+import {
+  Environment,
+  Pagination,
+} from '@kyverno/backstage-plugin-policy-reporter-common';
 import { useApi } from '@backstage/core-plugin-api';
 import { policyReporterApiRef } from '../api';
 import {
@@ -14,10 +17,15 @@ const DEFAULT_PAGE = 0;
 export const usePaginatedPolicies = (
   currentEnvironment: Environment,
   filter: Filter,
+  pagination?: Partial<Pagination>,
 ) => {
   const policyReporterApi = useApi(policyReporterApiRef);
-  const [currentPage, setCurrentPage] = useState<number>(DEFAULT_PAGE);
-  const [currentOffset, setCurrentOffset] = useState<number>(DEFAULT_OFFSET);
+  const [currentPage, setCurrentPage] = useState<number>(
+    pagination?.page ?? DEFAULT_PAGE,
+  );
+  const [currentOffset, setCurrentOffset] = useState<number>(
+    pagination?.offset ?? DEFAULT_OFFSET,
+  );
   const [initialLoading, setInitialLoading] = useState<boolean>(true);
 
   useEffect(() => {

--- a/plugins/policy-reporter/src/index.ts
+++ b/plugins/policy-reporter/src/index.ts
@@ -2,5 +2,5 @@ export {
   policyReporterPlugin,
   EntityKyvernoPoliciesContent,
   EntityCustomPoliciesContent,
-  PolicyReporterPage,
+  PolicyReportsPage,
 } from './plugin';

--- a/plugins/policy-reporter/src/plugin.ts
+++ b/plugins/policy-reporter/src/plugin.ts
@@ -44,9 +44,9 @@ export const EntityCustomPoliciesContent = policyReporterPlugin.provide(
   }),
 );
 
-export const PolicyReporterPage = policyReporterPlugin.provide(
+export const PolicyReportsPage = policyReporterPlugin.provide(
   createRoutableExtension({
-    name: 'PolicyReporterPage',
+    name: 'PolicyReportsPage',
     component: () =>
       import('./components/PolicyReportsPage').then(m => m.PolicyReportsPage),
     mountPoint: rootRouteRef,


### PR DESCRIPTION
## Description

This PR updates the `PolicyReportsPage` component to now render 1 big table showing all failed policies. It's now also possible to filter policies by status and severity

The exported component name has also been fixed to correctly be `PolicyReportsPage` instead of `PolicyReporterPage`

## Screenshot

![image](https://github.com/user-attachments/assets/a471c9a1-1657-43f9-8557-768f0d233c9e)
