### PR TITLE
chore(annotations): add support for kubernetes ns annotation

### DIFF
--- a/.changeset/little-otters-bathe.md
+++ b/.changeset/little-otters-bathe.md
@@ -1,0 +1,8 @@
+---
+'@kyverno/backstage-plugin-policy-reporter-common': minor
+'@kyverno/backstage-plugin-policy-reporter': minor
+---
+
+Add support for the `backstage.io/kubernetes-namespace` annotation as an alternative for the `kyverno.io/namespace`. This is useful for anyone already using the Kubernetes plugin. The kyverno namespaced annotation will always be the first priority.
+
+Add `isPolicyReporterAvailable` helper function to validate if PolicyReporter is configured for an entity.

--- a/plugins/policy-reporter-common/src/annotations.ts
+++ b/plugins/policy-reporter-common/src/annotations.ts
@@ -7,6 +7,10 @@ export const KYVERNO_KIND_ANNOTATION = 'kyverno.io/kind';
 // The namespace of the resource to display policies
 export const KYVERNO_NAMESPACE_ANNOTATION = 'kyverno.io/namespace';
 
+// The namespace of the resource to display policies
+export const KUBERNETES_NAMESPACE_ANNOTATION =
+  'backstage.io/kubernetes-namespace';
+
 // The endpoint for the Policy Reporter API
 // EXAMPLE: https://kyverno.io/policy-reporter/api/
 export const KYVERNO_ENDPOINT_ANNOTATION = 'kyverno.io/endpoint';

--- a/plugins/policy-reporter/src/components/EntityCustomPoliciesContent/EntityCustomPoliciesContent.tsx
+++ b/plugins/policy-reporter/src/components/EntityCustomPoliciesContent/EntityCustomPoliciesContent.tsx
@@ -12,16 +12,14 @@ import { Grid } from '@material-ui/core';
 import { PolicyReportsTable } from '../PolicyReportsTable';
 import { SelectEnvironment } from '../SelectEnvironment';
 import {
-  containsRequiredAnnotations,
-  annotationsRequired,
+  getKinds,
+  getNamespaces,
+  getResourceName,
+  isPolicyReporterAvailable,
 } from '../../utils/annotations';
 import { MissingEnvironmentsEmptyState } from '../MissingEnvironmentsEmptyState';
 import { useEntityEnvironment } from '../../hooks/useEntityEnvironment';
-import {
-  KYVERNO_KIND_ANNOTATION,
-  KYVERNO_NAMESPACE_ANNOTATION,
-  KYVERNO_RESOURCE_NAME_ANNOTATION,
-} from '@kyverno/backstage-plugin-policy-reporter-common';
+import { KYVERNO_RESOURCE_NAME_ANNOTATION } from '@kyverno/backstage-plugin-policy-reporter-common';
 
 type EntityCustomPoliciesContentProps = {
   annotationsDocumentationUrl?: string;
@@ -49,8 +47,7 @@ export const EntityCustomPoliciesContent = ({
   const { entity } = useEntity();
   const annotations = entity.metadata.annotations;
 
-  // Boolean variable to validate that entity have required annotations
-  const annotationsState: boolean = containsRequiredAnnotations(annotations);
+  const annotationsState = isPolicyReporterAvailable(entity);
 
   const {
     environments,
@@ -65,7 +62,7 @@ export const EntityCustomPoliciesContent = ({
       <PageContent>
         <MissingAnnotationEmptyState
           readMoreUrl={annotationsDocumentationUrl}
-          annotation={annotationsRequired}
+          annotation={KYVERNO_RESOURCE_NAME_ANNOTATION}
         />
       </PageContent>
     );
@@ -81,9 +78,9 @@ export const EntityCustomPoliciesContent = ({
       </PageContent>
     );
 
-  const namespaces = annotations![KYVERNO_NAMESPACE_ANNOTATION].split(',');
-  const kinds = annotations![KYVERNO_KIND_ANNOTATION].split(',');
-  const resourceName = annotations![KYVERNO_RESOURCE_NAME_ANNOTATION];
+  const namespaces = getNamespaces(annotations);
+  const kinds = getKinds(annotations);
+  const resourceName = getResourceName(annotations);
 
   return (
     <PageContent>

--- a/plugins/policy-reporter/src/components/EntityKyvernoPoliciesContent/EntityKyvernoPoliciesContent.tsx
+++ b/plugins/policy-reporter/src/components/EntityKyvernoPoliciesContent/EntityKyvernoPoliciesContent.tsx
@@ -12,16 +12,14 @@ import { Grid } from '@material-ui/core';
 import { PolicyReportsTable } from '../PolicyReportsTable';
 import { SelectEnvironment } from '../SelectEnvironment';
 import {
-  containsRequiredAnnotations,
-  annotationsRequired,
+  getKinds,
+  getNamespaces,
+  getResourceName,
+  isPolicyReporterAvailable,
 } from '../../utils/annotations';
 import { MissingEnvironmentsEmptyState } from '../MissingEnvironmentsEmptyState';
 import { useEntityEnvironment } from '../../hooks/useEntityEnvironment';
-import {
-  KYVERNO_KIND_ANNOTATION,
-  KYVERNO_NAMESPACE_ANNOTATION,
-  KYVERNO_RESOURCE_NAME_ANNOTATION,
-} from '@kyverno/backstage-plugin-policy-reporter-common';
+import { KYVERNO_RESOURCE_NAME_ANNOTATION } from '@kyverno/backstage-plugin-policy-reporter-common';
 
 type KyvernoPoliciesContentProps = {
   annotationsDocumentationUrl?: string;
@@ -46,7 +44,7 @@ export const EntityKyvernoPoliciesContent = ({
   const annotations = entity.metadata.annotations;
 
   // Boolean variable to validate that entity have required annotations
-  const annotationsState: boolean = containsRequiredAnnotations(annotations);
+  const annotationsState = isPolicyReporterAvailable(entity);
 
   const {
     environments,
@@ -61,7 +59,7 @@ export const EntityKyvernoPoliciesContent = ({
       <PageContent>
         <MissingAnnotationEmptyState
           readMoreUrl={annotationsDocumentationUrl}
-          annotation={annotationsRequired}
+          annotation={KYVERNO_RESOURCE_NAME_ANNOTATION}
         />
       </PageContent>
     );
@@ -77,9 +75,9 @@ export const EntityKyvernoPoliciesContent = ({
       </PageContent>
     );
 
-  const namespaces = annotations![KYVERNO_NAMESPACE_ANNOTATION].split(',');
-  const kinds = annotations![KYVERNO_KIND_ANNOTATION].split(',');
-  const resourceName = annotations![KYVERNO_RESOURCE_NAME_ANNOTATION];
+  const namespaces = getNamespaces(annotations);
+  const kinds = getKinds(annotations);
+  const resourceName = getResourceName(annotations);
 
   return (
     <PageContent>

--- a/plugins/policy-reporter/src/utils/annotations.test.ts
+++ b/plugins/policy-reporter/src/utils/annotations.test.ts
@@ -111,16 +111,6 @@ describe('annotations utils', () => {
 
       expect(result).toEqual([]);
     });
-
-    it('should handle empty Kyverno namespace annotation', () => {
-      const annotations = {
-        [KYVERNO_NAMESPACE_ANNOTATION]: '',
-      };
-
-      const result = getNamespaces(annotations);
-
-      expect(result).toEqual(['']);
-    });
   });
 
   describe('getKinds', () => {
@@ -168,16 +158,6 @@ describe('annotations utils', () => {
       const result = getKinds(undefined);
 
       expect(result).toEqual([]);
-    });
-
-    it('should handle empty kind annotation', () => {
-      const annotations = {
-        [KYVERNO_KIND_ANNOTATION]: '',
-      };
-
-      const result = getKinds(annotations);
-
-      expect(result).toEqual(['']);
     });
   });
 

--- a/plugins/policy-reporter/src/utils/annotations.test.ts
+++ b/plugins/policy-reporter/src/utils/annotations.test.ts
@@ -1,0 +1,344 @@
+import {
+  containsRequiredAnnotations,
+  getNamespaces,
+  getKinds,
+  getResourceName,
+} from './annotations';
+import {
+  KYVERNO_KIND_ANNOTATION,
+  KYVERNO_NAMESPACE_ANNOTATION,
+  KYVERNO_RESOURCE_NAME_ANNOTATION,
+  KUBERNETES_NAMESPACE_ANNOTATION,
+} from '@kyverno/backstage-plugin-policy-reporter-common';
+
+describe('annotations utils', () => {
+  describe('containsRequiredAnnotations', () => {
+    it('should return true when all required annotations are present', () => {
+      const annotations = {
+        annotation1: 'value1',
+        annotation2: 'value2',
+        annotation3: 'value3',
+      };
+      const required = ['annotation1', 'annotation2'];
+
+      const result = containsRequiredAnnotations(annotations, required);
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false when some required annotations are missing', () => {
+      const annotations = {
+        annotation1: 'value1',
+        annotation3: 'value3',
+      };
+      const required = ['annotation1', 'annotation2'];
+
+      const result = containsRequiredAnnotations(annotations, required);
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false when annotations is undefined', () => {
+      const required = ['annotation1', 'annotation2'];
+
+      const result = containsRequiredAnnotations(undefined, required);
+
+      expect(result).toBe(false);
+    });
+
+    it('should return true when required array is empty', () => {
+      const annotations = {
+        annotation1: 'value1',
+      };
+      const required: string[] = [];
+
+      const result = containsRequiredAnnotations(annotations, required);
+
+      expect(result).toBe(true);
+    });
+
+    it('should return true when both annotations and required are empty', () => {
+      const annotations = {};
+      const required: string[] = [];
+
+      const result = containsRequiredAnnotations(annotations, required);
+
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('getNamespaces', () => {
+    it('should return Kyverno namespace annotation as array when present', () => {
+      const annotations = {
+        [KYVERNO_NAMESPACE_ANNOTATION]: 'namespace1,namespace2,namespace3',
+      };
+
+      const result = getNamespaces(annotations);
+
+      expect(result).toEqual(['namespace1', 'namespace2', 'namespace3']);
+    });
+
+    it('should trim whitespace from Kyverno namespace values', () => {
+      const annotations = {
+        [KYVERNO_NAMESPACE_ANNOTATION]:
+          ' namespace1 , namespace2 , namespace3 ',
+      };
+
+      const result = getNamespaces(annotations);
+
+      expect(result).toEqual(['namespace1', 'namespace2', 'namespace3']);
+    });
+
+    it('should return single Kyverno namespace as array', () => {
+      const annotations = {
+        [KYVERNO_NAMESPACE_ANNOTATION]: 'single-namespace',
+      };
+
+      const result = getNamespaces(annotations);
+
+      expect(result).toEqual(['single-namespace']);
+    });
+
+    it('should fall back to Kubernetes namespace annotation when Kyverno annotation is not present', () => {
+      const annotations = {
+        [KUBERNETES_NAMESPACE_ANNOTATION]: 'kubernetes-namespace',
+      };
+
+      const result = getNamespaces(annotations);
+
+      expect(result).toEqual(['kubernetes-namespace']);
+    });
+
+    it('should prioritize Kyverno annotation over Kubernetes annotation', () => {
+      const annotations = {
+        [KYVERNO_NAMESPACE_ANNOTATION]: 'kyverno-namespace',
+        [KUBERNETES_NAMESPACE_ANNOTATION]: 'kubernetes-namespace',
+      };
+
+      const result = getNamespaces(annotations);
+
+      expect(result).toEqual(['kyverno-namespace']);
+    });
+
+    it('should return empty array when no namespace annotations are present', () => {
+      const annotations = {
+        'other-annotation': 'value',
+      };
+
+      const result = getNamespaces(annotations);
+
+      expect(result).toEqual([]);
+    });
+
+    it('should return empty array when annotations is undefined', () => {
+      const result = getNamespaces(undefined);
+
+      expect(result).toEqual([]);
+    });
+
+    it('should handle empty Kyverno namespace annotation', () => {
+      const annotations = {
+        [KYVERNO_NAMESPACE_ANNOTATION]: '',
+      };
+
+      const result = getNamespaces(annotations);
+
+      expect(result).toEqual(['']);
+    });
+
+    it('should handle Kyverno namespace annotation with only commas and whitespace', () => {
+      const annotations = {
+        [KYVERNO_NAMESPACE_ANNOTATION]: ' , , ',
+      };
+
+      const result = getNamespaces(annotations);
+
+      expect(result).toEqual(['', '', '']);
+    });
+  });
+
+  describe('getKinds', () => {
+    it('should return kinds array when Kyverno kind annotation is present', () => {
+      const annotations = {
+        [KYVERNO_KIND_ANNOTATION]: 'Pod,Service,Deployment',
+      };
+
+      const result = getKinds(annotations);
+
+      expect(result).toEqual(['Pod', 'Service', 'Deployment']);
+    });
+
+    it('should trim whitespace from kind values', () => {
+      const annotations = {
+        [KYVERNO_KIND_ANNOTATION]: ' Pod , Service , Deployment ',
+      };
+
+      const result = getKinds(annotations);
+
+      expect(result).toEqual(['Pod', 'Service', 'Deployment']);
+    });
+
+    it('should return single kind as array', () => {
+      const annotations = {
+        [KYVERNO_KIND_ANNOTATION]: 'Pod',
+      };
+
+      const result = getKinds(annotations);
+
+      expect(result).toEqual(['Pod']);
+    });
+
+    it('should return empty array when kind annotation is not present', () => {
+      const annotations = {
+        'other-annotation': 'value',
+      };
+
+      const result = getKinds(annotations);
+
+      expect(result).toEqual([]);
+    });
+
+    it('should return empty array when annotations is undefined', () => {
+      const result = getKinds(undefined);
+
+      expect(result).toEqual([]);
+    });
+
+    it('should handle empty kind annotation', () => {
+      const annotations = {
+        [KYVERNO_KIND_ANNOTATION]: '',
+      };
+
+      const result = getKinds(annotations);
+
+      expect(result).toEqual(['']);
+    });
+
+    it('should handle kind annotation with only commas and whitespace', () => {
+      const annotations = {
+        [KYVERNO_KIND_ANNOTATION]: ' , , ',
+      };
+
+      const result = getKinds(annotations);
+
+      expect(result).toEqual(['', '', '']);
+    });
+  });
+
+  describe('getResourceName', () => {
+    it('should return resource name when annotation is present', () => {
+      const annotations = {
+        [KYVERNO_RESOURCE_NAME_ANNOTATION]: 'my-resource',
+      };
+
+      const result = getResourceName(annotations);
+
+      expect(result).toBe('my-resource');
+    });
+
+    it('should return empty string when resource name annotation is not present', () => {
+      const annotations = {
+        'other-annotation': 'value',
+      };
+
+      const result = getResourceName(annotations);
+
+      expect(result).toBe('');
+    });
+
+    it('should return empty string when annotations is undefined', () => {
+      const result = getResourceName(undefined);
+
+      expect(result).toBe('');
+    });
+
+    it('should return empty string when resource name annotation is empty', () => {
+      const annotations = {
+        [KYVERNO_RESOURCE_NAME_ANNOTATION]: '',
+      };
+
+      const result = getResourceName(annotations);
+
+      expect(result).toBe('');
+    });
+
+    it('should return resource name with special characters', () => {
+      const annotations = {
+        [KYVERNO_RESOURCE_NAME_ANNOTATION]: 'my-resource_123.test',
+      };
+
+      const result = getResourceName(annotations);
+
+      expect(result).toBe('my-resource_123.test');
+    });
+
+    it('should handle undefined annotation value gracefully', () => {
+      const annotations = {
+        [KYVERNO_RESOURCE_NAME_ANNOTATION]: undefined as any,
+      };
+
+      const result = getResourceName(annotations);
+
+      expect(result).toBe('');
+    });
+  });
+
+  describe('integration tests', () => {
+    it('should work with real-world Backstage entity annotations', () => {
+      const entityAnnotations = {
+        [KYVERNO_NAMESPACE_ANNOTATION]: 'production,staging',
+        [KYVERNO_KIND_ANNOTATION]: 'Pod,Service',
+        [KYVERNO_RESOURCE_NAME_ANNOTATION]: 'my-app',
+        [KUBERNETES_NAMESPACE_ANNOTATION]: 'default', // Should be ignored due to priority
+        'backstage.io/managed-by-location':
+          'url:https://github.com/example/repo',
+        'github.com/project-slug': 'example/repo',
+      };
+
+      const requiredAnnotations = [
+        KYVERNO_NAMESPACE_ANNOTATION,
+        KYVERNO_KIND_ANNOTATION,
+        KYVERNO_RESOURCE_NAME_ANNOTATION,
+      ];
+
+      expect(
+        containsRequiredAnnotations(entityAnnotations, requiredAnnotations),
+      ).toBe(true);
+      expect(getNamespaces(entityAnnotations)).toEqual([
+        'production',
+        'staging',
+      ]);
+      expect(getKinds(entityAnnotations)).toEqual(['Pod', 'Service']);
+      expect(getResourceName(entityAnnotations)).toBe('my-app');
+    });
+
+    it('should handle minimal Backstage entity with only Kubernetes namespace', () => {
+      const entityAnnotations = {
+        [KUBERNETES_NAMESPACE_ANNOTATION]: 'default',
+        'backstage.io/managed-by-location':
+          'url:https://github.com/example/repo',
+      };
+
+      expect(getNamespaces(entityAnnotations)).toEqual(['default']);
+      expect(getKinds(entityAnnotations)).toEqual([]);
+      expect(getResourceName(entityAnnotations)).toBe('');
+    });
+
+    it('should handle entity with no relevant annotations', () => {
+      const entityAnnotations = {
+        'backstage.io/managed-by-location':
+          'url:https://github.com/example/repo',
+        'github.com/project-slug': 'example/repo',
+      };
+
+      const requiredAnnotations = [KYVERNO_NAMESPACE_ANNOTATION];
+
+      expect(
+        containsRequiredAnnotations(entityAnnotations, requiredAnnotations),
+      ).toBe(false);
+      expect(getNamespaces(entityAnnotations)).toEqual([]);
+      expect(getKinds(entityAnnotations)).toEqual([]);
+      expect(getResourceName(entityAnnotations)).toBe('');
+    });
+  });
+});

--- a/plugins/policy-reporter/src/utils/annotations.ts
+++ b/plugins/policy-reporter/src/utils/annotations.ts
@@ -2,20 +2,83 @@ import {
   KYVERNO_KIND_ANNOTATION,
   KYVERNO_NAMESPACE_ANNOTATION,
   KYVERNO_RESOURCE_NAME_ANNOTATION,
+  KUBERNETES_NAMESPACE_ANNOTATION,
 } from '@kyverno/backstage-plugin-policy-reporter-common';
 
-// Define all annotations required for the component to work
-export const annotationsRequired: string[] = [
-  KYVERNO_RESOURCE_NAME_ANNOTATION,
-  KYVERNO_KIND_ANNOTATION,
-  KYVERNO_NAMESPACE_ANNOTATION,
-];
+/**
+ * Utility functions for working with Backstage entity annotations
+ * specifically for Kyverno policy reporter plugin integration
+ */
 
-// Check annotations object for all required annotations
+/**
+ * Validates that an annotations object contains all required annotation keys
+ * @param annotations - The annotations object from a Backstage entity (optional)
+ * @param required - Array of required annotation keys to check for
+ * @returns true if all required keys exist in annotations, false otherwise
+ */
 export const containsRequiredAnnotations = (
   annotations: Record<string, string> | undefined,
+  required: string[],
 ): boolean => {
-  return annotations
-    ? annotationsRequired.every(key => key in annotations)
-    : false;
+  return annotations ? required.every(key => key in annotations) : false;
+};
+
+/**
+ * Extracts namespace values from annotations, supporting both Kyverno and Kubernetes formats
+ * Priority: Kyverno namespace annotation (comma-separated) > Kubernetes namespace annotation (single value)
+ * @param annotations - The annotations object from a Backstage entity (optional)
+ * @returns Array of namespace strings, empty array if no namespace annotations found
+ */
+export const getNamespaces = (
+  annotations: Record<string, string> | undefined,
+): string[] => {
+  if (!annotations) return [];
+
+  // Check for Kyverno-specific namespace annotation (supports multiple namespaces)
+  if (annotations[KYVERNO_NAMESPACE_ANNOTATION]) {
+    return annotations[KYVERNO_NAMESPACE_ANNOTATION].split(',').map(item =>
+      item.trim(),
+    );
+  }
+
+  // Fall back to standard Kubernetes namespace annotation (single namespace)
+  if (annotations[KUBERNETES_NAMESPACE_ANNOTATION]) {
+    return [annotations[KUBERNETES_NAMESPACE_ANNOTATION]];
+  }
+
+  return [];
+};
+
+/**
+ * Extracts Kubernetes resource kinds from Kyverno-specific annotation
+ * @param annotations - The annotations object from a Backstage entity (optional)
+ * @returns Array of Kubernetes resource kind strings (e.g., ['Pod', 'Service']), empty array if not found
+ */
+export const getKinds = (
+  annotations: Record<string, string> | undefined,
+): string[] => {
+  if (!annotations) return [];
+
+  // Parse comma-separated list of Kubernetes resource kinds
+  if (annotations[KYVERNO_KIND_ANNOTATION]) {
+    return annotations[KYVERNO_KIND_ANNOTATION].split(',').map(item =>
+      item.trim(),
+    );
+  }
+
+  return [];
+};
+
+/**
+ * Extracts a specific resource name from Kyverno annotation
+ * Used to target a particular Kubernetes resource for policy evaluation
+ * @param annotations - The annotations object from a Backstage entity (optional)
+ * @returns Resource name string, empty string if annotation not found
+ */
+export const getResourceName = (
+  annotations: Record<string, string> | undefined,
+): string => {
+  if (!annotations) return '';
+
+  return annotations[KYVERNO_RESOURCE_NAME_ANNOTATION] || '';
 };

--- a/plugins/policy-reporter/src/utils/annotations.ts
+++ b/plugins/policy-reporter/src/utils/annotations.ts
@@ -1,3 +1,4 @@
+import { Entity } from '@backstage/catalog-model';
 import {
   KYVERNO_KIND_ANNOTATION,
   KYVERNO_NAMESPACE_ANNOTATION,
@@ -22,6 +23,14 @@ export const containsRequiredAnnotations = (
 ): boolean => {
   return annotations ? required.every(key => key in annotations) : false;
 };
+
+/**
+ * Validates that an entity has configured policy reporter
+ * @param entity - The the Backstage entity
+ * @returns true if policy reporter is configured.
+ */
+export const isPolicyReporterAvailable = (entity: Entity) =>
+  Boolean(entity.metadata.annotations?.[KYVERNO_RESOURCE_NAME_ANNOTATION]);
 
 /**
  * Extracts namespace values from annotations, supporting both Kyverno and Kubernetes formats


### PR DESCRIPTION
Add support for the `backstage.io/kubernetes-namespace` annotation as an alternative for the `kyverno.io/namespace`. This is useful for anyone already using the Kubernetes plugin. The kyverno namespaced annotation will always be the first priority.

Add `isPolicyReporterAvailable` helper function to validate if PolicyReporter is configured for an entity.

Part of #36 