### PR TITLE
feat(bui): migrate frontend components to use new bui

### DIFF
--- a/.changeset/lazy-swans-admire.md
+++ b/.changeset/lazy-swans-admire.md
@@ -1,0 +1,9 @@
+---
+'@kyverno/backstage-plugin-policy-reporter': minor
+---
+
+Migrated several components to the new Backstage UI (BUI) components, replacing legacy MUI-based implementations:
+
+- `PolicyReportsPage`, `EntityKyvernoPoliciesContent`, and `EntityCustomPoliciesContent` now use BUI `Grid`, `Container`, and `HeaderPage` for layout.
+- Filter selectors (`SelectEnvironment`, `SelectNamespace`, `SelectSeverity`, `SelectStatus`) now use the BUI `Select` component.
+- Severity badges now use the BUI `Tag` and `TagGroup` components instead of MUI chips.

--- a/plugins/policy-reporter/src/components/EntityCustomPoliciesContent/EntityCustomPoliciesContent.tsx
+++ b/plugins/policy-reporter/src/components/EntityCustomPoliciesContent/EntityCustomPoliciesContent.tsx
@@ -100,7 +100,7 @@ export const EntityCustomPoliciesContent = ({
       <ContentHeader title={title}>
         <SelectEnvironment
           environments={environments}
-          currentEnvironment={currentEnvironment}
+          initialEnvironment={currentEnvironment}
           setCurrentEnvironment={setCurrentEnvironment}
         />
       </ContentHeader>

--- a/plugins/policy-reporter/src/components/EntityCustomPoliciesContent/EntityCustomPoliciesContent.tsx
+++ b/plugins/policy-reporter/src/components/EntityCustomPoliciesContent/EntityCustomPoliciesContent.tsx
@@ -1,16 +1,11 @@
 import { useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import {
-  Content,
-  ContentHeader,
-  Page,
-  Progress,
-} from '@backstage/core-components';
+import { Content, Progress } from '@backstage/core-components';
 import {
   MissingAnnotationEmptyState,
   useEntity,
 } from '@backstage/plugin-catalog-react';
-import { Grid } from '@material-ui/core';
+import { Container, Grid, HeaderPage } from '@backstage/ui';
 import { PolicyReportsTable } from '../PolicyReportsTable';
 import { SelectEnvironment } from '../SelectEnvironment';
 import {
@@ -29,16 +24,6 @@ type EntityCustomPoliciesContentProps = {
   sources: string[];
   title: string;
 };
-
-type PageContentProps = {
-  children: React.ReactNode;
-};
-
-const PageContent = ({ children }: PageContentProps) => (
-  <Page themeId="tool">
-    <Content>{children}</Content>
-  </Page>
-);
 
 export const EntityCustomPoliciesContent = ({
   annotationsDocumentationUrl,
@@ -76,12 +61,14 @@ export const EntityCustomPoliciesContent = ({
   // Annotations missing
   if (!annotationsState)
     return (
-      <PageContent>
-        <MissingAnnotationEmptyState
-          readMoreUrl={annotationsDocumentationUrl}
-          annotation={KYVERNO_RESOURCE_NAME_ANNOTATION}
-        />
-      </PageContent>
+      <Container>
+        <Content>
+          <MissingAnnotationEmptyState
+            readMoreUrl={annotationsDocumentationUrl}
+            annotation={KYVERNO_RESOURCE_NAME_ANNOTATION}
+          />
+        </Content>
+      </Container>
     );
 
   // Fetching environments
@@ -90,22 +77,27 @@ export const EntityCustomPoliciesContent = ({
   // Environments missing
   if (environments === undefined || !currentEnvironment)
     return (
-      <PageContent>
-        <MissingEnvironmentsEmptyState entity={entity} />
-      </PageContent>
+      <Container>
+        <Content>
+          <MissingEnvironmentsEmptyState entity={entity} />
+        </Content>
+      </Container>
     );
 
   return (
-    <PageContent>
-      <ContentHeader title={title}>
-        <SelectEnvironment
-          environments={environments}
-          initialEnvironment={currentEnvironment}
-          setCurrentEnvironment={setCurrentEnvironment}
-        />
-      </ContentHeader>
-      <Grid container spacing={2}>
-        <Grid item xs={12}>
+    <Container>
+      <HeaderPage
+        title={title}
+        customActions={
+          <SelectEnvironment
+            environments={environments}
+            initialEnvironment={currentEnvironment}
+            setCurrentEnvironment={setCurrentEnvironment}
+          />
+        }
+      />
+      <Content>
+        <Grid.Root columns="1" gap="4">
           <PolicyReportsTable
             currentEnvironment={currentEnvironment}
             filter={{
@@ -116,8 +108,8 @@ export const EntityCustomPoliciesContent = ({
             emptyContentText="No policies"
             policyDocumentationUrl={policyDocumentationUrl}
           />
-        </Grid>
-      </Grid>
-    </PageContent>
+        </Grid.Root>
+      </Content>
+    </Container>
   );
 };

--- a/plugins/policy-reporter/src/components/EntityKyvernoPoliciesContent/EntityKyvernoPoliciesContent.tsx
+++ b/plugins/policy-reporter/src/components/EntityKyvernoPoliciesContent/EntityKyvernoPoliciesContent.tsx
@@ -1,16 +1,11 @@
 import { useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import {
-  Content,
-  ContentHeader,
-  Page,
-  Progress,
-} from '@backstage/core-components';
+import { Content, Progress } from '@backstage/core-components';
 import {
   MissingAnnotationEmptyState,
   useEntity,
 } from '@backstage/plugin-catalog-react';
-import { Grid } from '@material-ui/core';
+import { Container, Grid, HeaderPage } from '@backstage/ui';
 import { PolicyReportsTable } from '../PolicyReportsTable';
 import { SelectEnvironment } from '../SelectEnvironment';
 import {
@@ -27,16 +22,6 @@ type KyvernoPoliciesContentProps = {
   annotationsDocumentationUrl?: string;
   policyDocumentationUrl?: string;
 };
-
-type PageContentProps = {
-  children: React.ReactNode;
-};
-
-const PageContent = ({ children }: PageContentProps) => (
-  <Page themeId="tool">
-    <Content>{children}</Content>
-  </Page>
-);
 
 export const EntityKyvernoPoliciesContent = ({
   annotationsDocumentationUrl,
@@ -73,12 +58,14 @@ export const EntityKyvernoPoliciesContent = ({
   // Annotations missing
   if (!annotationsState)
     return (
-      <PageContent>
-        <MissingAnnotationEmptyState
-          readMoreUrl={annotationsDocumentationUrl}
-          annotation={KYVERNO_RESOURCE_NAME_ANNOTATION}
-        />
-      </PageContent>
+      <Container>
+        <Content>
+          <MissingAnnotationEmptyState
+            readMoreUrl={annotationsDocumentationUrl}
+            annotation={KYVERNO_RESOURCE_NAME_ANNOTATION}
+          />
+        </Content>
+      </Container>
     );
 
   // Fetching environments
@@ -87,22 +74,27 @@ export const EntityKyvernoPoliciesContent = ({
   // Environments missing
   if (environments === undefined || !currentEnvironment)
     return (
-      <PageContent>
-        <MissingEnvironmentsEmptyState entity={entity} />
-      </PageContent>
+      <Container>
+        <Content>
+          <MissingEnvironmentsEmptyState entity={entity} />
+        </Content>
+      </Container>
     );
 
   return (
-    <PageContent>
-      <ContentHeader title="Kyverno Policy Reports">
-        <SelectEnvironment
-          environments={environments}
-          initialEnvironment={currentEnvironment}
-          setCurrentEnvironment={setCurrentEnvironment}
-        />
-      </ContentHeader>
-      <Grid container spacing={2}>
-        <Grid item xs={12}>
+    <Container>
+      <HeaderPage
+        title="Kyverno Policy Reports"
+        customActions={
+          <SelectEnvironment
+            environments={environments}
+            initialEnvironment={currentEnvironment}
+            setCurrentEnvironment={setCurrentEnvironment}
+          />
+        }
+      />
+      <Content>
+        <Grid.Root columns="1" gap="4">
           <PolicyReportsTable
             currentEnvironment={currentEnvironment}
             filter={{
@@ -113,8 +105,8 @@ export const EntityKyvernoPoliciesContent = ({
             emptyContentText="No policies found"
             policyDocumentationUrl={policyDocumentationUrl}
           />
-        </Grid>
-      </Grid>
-    </PageContent>
+        </Grid.Root>
+      </Content>
+    </Container>
   );
 };

--- a/plugins/policy-reporter/src/components/EntityKyvernoPoliciesContent/EntityKyvernoPoliciesContent.tsx
+++ b/plugins/policy-reporter/src/components/EntityKyvernoPoliciesContent/EntityKyvernoPoliciesContent.tsx
@@ -25,7 +25,6 @@ import { KYVERNO_RESOURCE_NAME_ANNOTATION } from '@kyverno/backstage-plugin-poli
 
 type KyvernoPoliciesContentProps = {
   annotationsDocumentationUrl?: string;
-  policyDocumentationUrl?: string;
 };
 
 type PageContentProps = {
@@ -40,7 +39,6 @@ const PageContent = ({ children }: PageContentProps) => (
 
 export const EntityKyvernoPoliciesContent = ({
   annotationsDocumentationUrl,
-  policyDocumentationUrl,
 }: KyvernoPoliciesContentProps) => {
   const { entity } = useEntity();
   const annotations = entity.metadata.annotations;

--- a/plugins/policy-reporter/src/components/EntityKyvernoPoliciesContent/EntityKyvernoPoliciesContent.tsx
+++ b/plugins/policy-reporter/src/components/EntityKyvernoPoliciesContent/EntityKyvernoPoliciesContent.tsx
@@ -97,7 +97,7 @@ export const EntityKyvernoPoliciesContent = ({
       <ContentHeader title="Kyverno Policy Reports">
         <SelectEnvironment
           environments={environments}
-          currentEnvironment={currentEnvironment}
+          initialEnvironment={currentEnvironment}
           setCurrentEnvironment={setCurrentEnvironment}
         />
       </ContentHeader>

--- a/plugins/policy-reporter/src/components/EntityKyvernoPoliciesContent/EntityKyvernoPoliciesContent.tsx
+++ b/plugins/policy-reporter/src/components/EntityKyvernoPoliciesContent/EntityKyvernoPoliciesContent.tsx
@@ -25,6 +25,7 @@ import { KYVERNO_RESOURCE_NAME_ANNOTATION } from '@kyverno/backstage-plugin-poli
 
 type KyvernoPoliciesContentProps = {
   annotationsDocumentationUrl?: string;
+  policyDocumentationUrl?: string;
 };
 
 type PageContentProps = {
@@ -39,6 +40,7 @@ const PageContent = ({ children }: PageContentProps) => (
 
 export const EntityKyvernoPoliciesContent = ({
   annotationsDocumentationUrl,
+  policyDocumentationUrl,
 }: KyvernoPoliciesContentProps) => {
   const { entity } = useEntity();
   const annotations = entity.metadata.annotations;

--- a/plugins/policy-reporter/src/components/PolicyReportsPage/PolicyReportsPage.test.tsx
+++ b/plugins/policy-reporter/src/components/PolicyReportsPage/PolicyReportsPage.test.tsx
@@ -63,9 +63,9 @@ describe('EntityKyvernoPolicyReportsContent component', () => {
 
     // Assert
     expect(extension.getByText('Policy Reports')).toBeTruthy();
-    expect(extension.getByText('Name')).toBeTruthy();
-    expect(extension.getByText('Namespace')).toBeTruthy();
-    expect(extension.getByText('Kind')).toBeTruthy();
-    expect(extension.getByText('Policy')).toBeTruthy();
+    expect(extension.getAllByText('Name')).toBeTruthy();
+    expect(extension.getAllByText('Namespace')).toBeTruthy();
+    expect(extension.getAllByText('Kind')).toBeTruthy();
+    expect(extension.getAllByText('Policy')).toBeTruthy();
   });
 });

--- a/plugins/policy-reporter/src/components/PolicyReportsPage/PolicyReportsPage.tsx
+++ b/plugins/policy-reporter/src/components/PolicyReportsPage/PolicyReportsPage.tsx
@@ -7,9 +7,9 @@ import {
   Page,
   Progress,
 } from '@backstage/core-components';
+import { Box, Button, Grid } from '@material-ui/core';
 import { useEnvironments } from '../../hooks/useEnvironments';
 import { SelectEnvironment } from '../SelectEnvironment';
-import { Button, Grid } from '@material-ui/core';
 import { PolicyReportsTable } from '../PolicyReportsTable';
 import { useState } from 'react';
 import {
@@ -84,24 +84,24 @@ export const PolicyReportsPage = ({
     <Page themeId="tool">
       <Header title={title} subtitle={subtitle} />
       <Content>
-        <ContentHeader>
-          <SelectStatus currentStatus={status} setStatus={setStatus} />
-          <SelectSeverity
-            currentSeverity={severity}
-            setSeverity={setSeverity}
+        <ContentHeader title="">
+          <SelectEnvironment
+            environments={environments}
+            initialEnvironment={currentEnvironment}
+            setCurrentEnvironment={setCurrentEnvironment}
           />
+        </ContentHeader>
+        <Box display="flex" alignItems="flex-end" gridGap={16} mb={2}>
+          <SelectStatus initialStatus="fail" setStatus={setStatus} />
+          <SelectSeverity setSeverity={setSeverity} />
           <SelectNamespace
-            currentNamespaces={selectedNamespaces}
             setNamespaces={setSelectedNamespaces}
             availableNamespaces={availableNamespaces}
           />
-          <SelectEnvironment
-            environments={environments}
-            currentEnvironment={currentEnvironment}
-            setCurrentEnvironment={setCurrentEnvironment}
-          />
-          <SearchField />
-        </ContentHeader>
+          <Box width={300} flexShrink={0}>
+            <SearchField />
+          </Box>
+        </Box>
         <Grid container spacing={2}>
           <Grid item xs={12}>
             <PolicyReportsTable

--- a/plugins/policy-reporter/src/components/PolicyReportsPage/PolicyReportsPage.tsx
+++ b/plugins/policy-reporter/src/components/PolicyReportsPage/PolicyReportsPage.tsx
@@ -1,5 +1,12 @@
 import { Content, EmptyState, Progress } from '@backstage/core-components';
-import { Box, Container, Flex, Grid, HeaderPage, ButtonLink } from '@backstage/ui';
+import {
+  Box,
+  Container,
+  Flex,
+  Grid,
+  HeaderPage,
+  ButtonLink,
+} from '@backstage/ui';
 import { useEnvironments } from '../../hooks/useEnvironments';
 import { SelectEnvironment } from '../SelectEnvironment';
 import { PolicyReportsTable } from '../PolicyReportsTable';

--- a/plugins/policy-reporter/src/components/PolicyReportsPage/PolicyReportsPage.tsx
+++ b/plugins/policy-reporter/src/components/PolicyReportsPage/PolicyReportsPage.tsx
@@ -24,12 +24,14 @@ import { SearchField } from '../SearchField';
 
 export interface PolicyReportsPageProps {
   title?: string;
+  policyDocumentationUrl?: string;
   subtitle?: string;
 }
 
 export const PolicyReportsPage = ({
   title = 'Policy Reports',
   subtitle = 'View all policy reports from a Kubernetes cluster',
+  policyDocumentationUrl,
 }: PolicyReportsPageProps) => {
   const {
     environments,

--- a/plugins/policy-reporter/src/components/PolicyReportsPage/PolicyReportsPage.tsx
+++ b/plugins/policy-reporter/src/components/PolicyReportsPage/PolicyReportsPage.tsx
@@ -24,14 +24,12 @@ import { SearchField } from '../SearchField';
 
 export interface PolicyReportsPageProps {
   title?: string;
-  policyDocumentationUrl?: string;
   subtitle?: string;
 }
 
 export const PolicyReportsPage = ({
   title = 'Policy Reports',
   subtitle = 'View all policy reports from a Kubernetes cluster',
-  policyDocumentationUrl,
 }: PolicyReportsPageProps) => {
   const {
     environments,

--- a/plugins/policy-reporter/src/components/PolicyReportsPage/PolicyReportsPage.tsx
+++ b/plugins/policy-reporter/src/components/PolicyReportsPage/PolicyReportsPage.tsx
@@ -1,13 +1,5 @@
-import {
-  Content,
-  ContentHeader,
-  EmptyState,
-  Header,
-  Link,
-  Page,
-  Progress,
-} from '@backstage/core-components';
-import { Box, Button, Grid } from '@material-ui/core';
+import { Content, EmptyState, Progress } from '@backstage/core-components';
+import { Box, Container, Flex, Grid, HeaderPage, ButtonLink } from '@backstage/ui';
 import { useEnvironments } from '../../hooks/useEnvironments';
 import { SelectEnvironment } from '../SelectEnvironment';
 import { PolicyReportsTable } from '../PolicyReportsTable';
@@ -30,7 +22,6 @@ export interface PolicyReportsPageProps {
 
 export const PolicyReportsPage = ({
   title = 'Policy Reports',
-  subtitle = 'View all policy reports from a Kubernetes cluster',
   policyDocumentationUrl,
 }: PolicyReportsPageProps) => {
   const {
@@ -51,8 +42,8 @@ export const PolicyReportsPage = ({
   // Environments missing
   if (environments === undefined || !currentEnvironment)
     return (
-      <Page themeId="tool">
-        <Header title={title} subtitle={subtitle} />
+      <Container>
+        <HeaderPage title={title} />
         <Content>
           <EmptyState
             missing="content"
@@ -66,57 +57,56 @@ export const PolicyReportsPage = ({
             }
             action={
               <>
-                <Button
-                  color="primary"
-                  component={Link}
-                  to="https://github.com/kyverno/backstage-policy-reporter-plugin"
+                <ButtonLink
+                  target="_blank"
+                  href="https://github.com/kyverno/backstage-policy-reporter-plugin"
                 >
                   Read More
-                </Button>
+                </ButtonLink>
               </>
             }
           />
         </Content>
-      </Page>
+      </Container>
     );
 
   return (
-    <Page themeId="tool">
-      <Header title={title} subtitle={subtitle} />
-      <Content>
-        <ContentHeader title="">
+    <Container>
+      <HeaderPage
+        title={title}
+        customActions={
           <SelectEnvironment
             environments={environments}
             initialEnvironment={currentEnvironment}
             setCurrentEnvironment={setCurrentEnvironment}
           />
-        </ContentHeader>
-        <Box display="flex" alignItems="flex-end" gridGap={16} mb={2}>
-          <SelectStatus initialStatus="fail" setStatus={setStatus} />
-          <SelectSeverity setSeverity={setSeverity} />
-          <SelectNamespace
-            setNamespaces={setSelectedNamespaces}
-            availableNamespaces={availableNamespaces}
-          />
-          <Box width={300} flexShrink={0}>
-            <SearchField />
-          </Box>
-        </Box>
-        <Grid container spacing={2}>
-          <Grid item xs={12}>
-            <PolicyReportsTable
-              currentEnvironment={currentEnvironment}
-              filter={{
-                status: status,
-                severities: severity,
-                namespaces: selectedNamespaces,
-              }}
-              emptyContentText="No policies found"
-              policyDocumentationUrl={policyDocumentationUrl}
+        }
+      />
+      <Content>
+        <Grid.Root columns="1" gap="4">
+          <Flex align="end" gap="4">
+            <SelectStatus initialStatus="fail" setStatus={setStatus} />
+            <SelectSeverity setSeverity={setSeverity} />
+            <SelectNamespace
+              setNamespaces={setSelectedNamespaces}
+              availableNamespaces={availableNamespaces}
             />
-          </Grid>
-        </Grid>
+            <Box width="300px" style={{ flexShrink: 0 }}>
+              <SearchField />
+            </Box>
+          </Flex>
+          <PolicyReportsTable
+            currentEnvironment={currentEnvironment}
+            filter={{
+              status: status,
+              severities: severity,
+              namespaces: selectedNamespaces,
+            }}
+            emptyContentText="No policies found"
+            policyDocumentationUrl={policyDocumentationUrl}
+          />
+        </Grid.Root>
       </Content>
-    </Page>
+    </Container>
   );
 };

--- a/plugins/policy-reporter/src/components/PolicyReportsTable/PolicyReportsTable.tsx
+++ b/plugins/policy-reporter/src/components/PolicyReportsTable/PolicyReportsTable.tsx
@@ -166,22 +166,6 @@ export const PolicyReportsTable = ({
       >
         <PolicyReportsDrawerComponent content={drawerContent} />
       </Drawer>
-      {/* <SearchField */}
-      {/*   size="small" */}
-      {/*   aria-label="Search" */}
-      {/*   placeholder="Search..." */}
-      {/*   {...search} */}
-      {/* /> */}
-
-      {enableSearch && (
-        <SearchField
-          aria-label="Search"
-          label="Search"
-          value={search.value}
-          onChange={search.onChange}
-          style={{ width: '350px' }}
-        />
-      )}
       <Table
         rowConfig={{
           onClick: item => setDrawerContent(item),

--- a/plugins/policy-reporter/src/components/PolicyReportsTable/PolicyReportsTable.tsx
+++ b/plugins/policy-reporter/src/components/PolicyReportsTable/PolicyReportsTable.tsx
@@ -166,6 +166,22 @@ export const PolicyReportsTable = ({
       >
         <PolicyReportsDrawerComponent content={drawerContent} />
       </Drawer>
+      {/* <SearchField */}
+      {/*   size="small" */}
+      {/*   aria-label="Search" */}
+      {/*   placeholder="Search..." */}
+      {/*   {...search} */}
+      {/* /> */}
+
+      {enableSearch && (
+        <SearchField
+          aria-label="Search"
+          label="Search"
+          value={search.value}
+          onChange={search.onChange}
+          style={{ width: '350px' }}
+        />
+      )}
       <Table
         rowConfig={{
           onClick: item => setDrawerContent(item),

--- a/plugins/policy-reporter/src/components/SelectEnvironment/SelectEnvironment.test.tsx
+++ b/plugins/policy-reporter/src/components/SelectEnvironment/SelectEnvironment.test.tsx
@@ -16,14 +16,14 @@ describe('SelectEnvironment', () => {
     const extension = await renderInTestApp(
       <SelectEnvironment
         environments={environments}
-        currentEnvironment={environments[1]}
+        initialEnvironment={environments[1]}
         setCurrentEnvironment={setCurrentEnvironment}
       />,
     );
 
-    expect(extension.getByText('prod')).toBeTruthy();
+    expect(extension.getAllByText('prod')).toBeTruthy();
   });
-  it('should be disabled if theres only 1 environment', async () => {
+  it('should render correctly with a single environment', async () => {
     const environment: Environment = {
       id: 1,
       entityRef: 'resource:default/dev',
@@ -34,15 +34,13 @@ describe('SelectEnvironment', () => {
     const extension = await renderInTestApp(
       <SelectEnvironment
         environments={[environment]}
-        currentEnvironment={environment}
+        initialEnvironment={environment}
         setCurrentEnvironment={setCurrentEnvironment}
       />,
     );
 
     // Assert
-    expect(extension.getAllByText('Environment')).toHaveLength(1);
-    expect(extension.getByText('dev')).toBeTruthy();
-    // The button should be disabled
-    expect(extension.getByText('dev')).toHaveClass('Mui-disabled');
+    expect(extension.getByText('Environment')).toBeTruthy();
+    expect(extension.getAllByText('dev')).toBeTruthy();
   });
 });

--- a/plugins/policy-reporter/src/components/SelectEnvironment/SelectEnvironment.tsx
+++ b/plugins/policy-reporter/src/components/SelectEnvironment/SelectEnvironment.tsx
@@ -1,59 +1,37 @@
-import MenuItem from '@material-ui/core/MenuItem';
-import InputLabel from '@material-ui/core/InputLabel';
-import FormControl from '@material-ui/core/FormControl';
-import Select from '@material-ui/core/Select';
+import { Select } from '@backstage/ui';
 import { Environment } from '@kyverno/backstage-plugin-policy-reporter-common';
-import { makeStyles } from '@material-ui/core/styles';
-
-const useStyles = makeStyles({
-  formControl: {
-    margin: 8,
-    minWidth: 150,
-  },
-  hideDropdownArrow: {
-    '& .MuiSelect-icon-196.Mui-disabled': {
-      display: 'none',
-    },
-  },
-});
+import { Key } from 'react';
 
 type SelectEnvironmentProps = {
   environments: Environment[];
-  currentEnvironment: Environment;
+  initialEnvironment: Environment;
   setCurrentEnvironment: (environment: Environment) => void;
 };
 
 export const SelectEnvironment = ({
   environments,
-  currentEnvironment,
+  initialEnvironment,
   setCurrentEnvironment,
 }: SelectEnvironmentProps) => {
-  const classes = useStyles();
+  const options = environments.map(env => ({
+    value: env.entityRef,
+    label: env.name,
+  }));
 
-  const handleChange = (event: any) => {
-    setCurrentEnvironment(environments[Number(event.target.value)]);
+  const handleChange = (key: Key | Key[] | null) => {
+    if (key === null || Array.isArray(key)) return;
+
+    const env = environments.find(e => e.entityRef === key);
+    if (env) setCurrentEnvironment(env);
   };
 
-  // Check if there is more then 1 environment
-  const isSingleEnvironment = environments.length === 1;
-
   return (
-    <FormControl className={classes.formControl}>
-      <InputLabel id="select-environment-label">Environment</InputLabel>
-      <Select
-        labelId="select-environment-label"
-        id="select-environment"
-        value={String(currentEnvironment.id)}
-        onChange={handleChange}
-        disabled={isSingleEnvironment}
-        className={isSingleEnvironment ? classes.hideDropdownArrow : ''}
-      >
-        {environments.map(env => (
-          <MenuItem key={env.name} value={env.id}>
-            {env.name}
-          </MenuItem>
-        ))}
-      </Select>
-    </FormControl>
+    <Select
+      label="Environment"
+      selectionMode="single"
+      options={options}
+      defaultValue={initialEnvironment.entityRef}
+      onChange={handleChange}
+    />
   );
 };

--- a/plugins/policy-reporter/src/components/SelectNamespace/SelectNamespace.test.tsx
+++ b/plugins/policy-reporter/src/components/SelectNamespace/SelectNamespace.test.tsx
@@ -5,39 +5,39 @@ const setNamespaces = jest.fn();
 const availableNamespaces = ['default', 'kube-system'];
 
 describe('SelectNamespace', () => {
-    it('should render the selected namespace', async () => {
-        const extension = await renderInTestApp(
-            <SelectNamespace
-                currentNamespaces={['default']}
-                setNamespaces={setNamespaces}
-                availableNamespaces={availableNamespaces}
-            />,
-        );
-        expect(extension.getByText('default')).toBeTruthy();
-        expect(extension.getByText('Namespaces')).toBeTruthy();
-    });
+  it('should render the selected namespace', async () => {
+    const extension = await renderInTestApp(
+      <SelectNamespace
+        initialNamespaces={['default']}
+        setNamespaces={setNamespaces}
+        availableNamespaces={availableNamespaces}
+      />,
+    );
+    expect(extension.getAllByText('default')).toBeTruthy();
+    expect(extension.getByText('Namespace')).toBeTruthy();
+  });
 
-    it('should render the selected namespaces', async () => {
-        const extension = await renderInTestApp(
-            <SelectNamespace
-                currentNamespaces={['default', 'kube-system']}
-                setNamespaces={setNamespaces}
-                availableNamespaces={availableNamespaces}
-            />,
-        );
-        expect(extension.getByText('default, kube-system')).toBeTruthy();
-        expect(extension.getByText('Namespaces')).toBeTruthy();
-    });
+  it('should render the selected namespaces', async () => {
+    const extension = await renderInTestApp(
+      <SelectNamespace
+        initialNamespaces={['default', 'kube-system']}
+        setNamespaces={setNamespaces}
+        availableNamespaces={availableNamespaces}
+      />,
+    );
+    expect(extension.getAllByText('default')).toBeTruthy();
+    expect(extension.getAllByText('kube-system')).toBeTruthy();
+    expect(extension.getByText('Namespace')).toBeTruthy();
+  });
 
-    it('should render all when nothing is selected', async () => {
-        const extension = await renderInTestApp(
-            <SelectNamespace
-                currentNamespaces={[]}
-                setNamespaces={setNamespaces}
-                availableNamespaces={availableNamespaces}
-            />,
-        );
-        expect(extension.getByText('All')).toBeTruthy();
-        expect(extension.getByText('Namespaces')).toBeTruthy();
-    });
+  it('should render all when nothing is selected', async () => {
+    const extension = await renderInTestApp(
+      <SelectNamespace
+        setNamespaces={setNamespaces}
+        availableNamespaces={availableNamespaces}
+      />,
+    );
+    expect(extension.getByText('All')).toBeTruthy();
+    expect(extension.getByText('Namespace')).toBeTruthy();
+  });
 });

--- a/plugins/policy-reporter/src/components/SelectNamespace/SelectNamespace.tsx
+++ b/plugins/policy-reporter/src/components/SelectNamespace/SelectNamespace.tsx
@@ -1,61 +1,47 @@
-import MenuItem from '@material-ui/core/MenuItem';
-import InputLabel from '@material-ui/core/InputLabel';
-import FormControl from '@material-ui/core/FormControl';
-import Select from '@material-ui/core/Select';
-import { makeStyles } from '@material-ui/core/styles';
-import { Checkbox, ListItemText } from '@material-ui/core';
-
-const useStyles = makeStyles({
-  formControl: {
-    margin: 8,
-    minWidth: 150,
-  },
-});
+import { Select } from '@backstage/ui';
+import { Key } from 'react';
 
 export type SelectNamespaceProps = {
-  currentNamespaces: string[];
+  initialNamespaces?: string[];
   setNamespaces: (namespaces: string[]) => void;
   availableNamespaces: string[];
 };
 
 export const SelectNamespace = ({
-  currentNamespaces,
+  initialNamespaces,
   setNamespaces,
   availableNamespaces,
 }: SelectNamespaceProps) => {
-  const classes = useStyles();
+  const options = availableNamespaces.map(ns => ({ value: ns, label: ns }));
 
-  const handleChange = (event: any) => {
-    setNamespaces(event.target.value);
+  const handleChange = (key: Key | Key[] | null) => {
+    if (key === null) {
+      setNamespaces([]);
+      return;
+    }
+
+    if (!Array.isArray(key)) {
+      setNamespaces(
+        availableNamespaces.includes(key as string) ? [key as string] : [],
+      );
+      return;
+    }
+
+    const filtered = key.filter((item): item is string =>
+      availableNamespaces.includes(item as string),
+    );
+    setNamespaces(filtered);
   };
 
   return (
-    <FormControl className={classes.formControl}>
-      <InputLabel id="select-namespace-label" shrink>
-        Namespaces
-      </InputLabel>
-      <Select
-        labelId="select-namespace-label"
-        id="select-namespace"
-        multiple
-        displayEmpty
-        value={currentNamespaces}
-        renderValue={selected => {
-          if ((selected as string[]).length === 0) {
-            return 'All';
-          }
-
-          return (selected as string[]).join(', ');
-        }}
-        onChange={handleChange}
-      >
-        {availableNamespaces.map(namespace => (
-          <MenuItem key={namespace} value={namespace}>
-            <Checkbox checked={currentNamespaces.includes(namespace)} />
-            <ListItemText primary={namespace} />
-          </MenuItem>
-        ))}
-      </Select>
-    </FormControl>
+    <Select
+      label="Namespace"
+      selectionMode="multiple"
+      options={options}
+      defaultValue={initialNamespaces}
+      onChange={handleChange}
+      placeholder="All"
+      style={{ width: 200 }}
+    />
   );
 };

--- a/plugins/policy-reporter/src/components/SelectSeverity/SelectSeverity.test.tsx
+++ b/plugins/policy-reporter/src/components/SelectSeverity/SelectSeverity.test.tsx
@@ -7,28 +7,29 @@ describe('SelectSeverity', () => {
   it('should render the selected environment', async () => {
     const extension = await renderInTestApp(
       <SelectSeverity
-        currentSeverity={['critical']}
+        initialSeverity={['critical']}
         setSeverity={setCurrentSeverity}
       />,
     );
-    expect(extension.getByText('critical')).toBeTruthy();
+    expect(extension.getAllByText('Critical')).toBeTruthy();
     expect(extension.getByText('Severity')).toBeTruthy();
   });
 
   it('should render the selected environments', async () => {
     const extension = await renderInTestApp(
       <SelectSeverity
-        currentSeverity={['info', 'low']}
+        initialSeverity={['info', 'low']}
         setSeverity={setCurrentSeverity}
       />,
     );
-    expect(extension.getByText('info, low')).toBeTruthy();
+    expect(extension.getAllByText('Info')).toBeTruthy();
+    expect(extension.getAllByText('Low')).toBeTruthy();
     expect(extension.getByText('Severity')).toBeTruthy();
   });
 
   it('should render all when nothing is selected', async () => {
     const extension = await renderInTestApp(
-      <SelectSeverity currentSeverity={[]} setSeverity={setCurrentSeverity} />,
+      <SelectSeverity initialSeverity={[]} setSeverity={setCurrentSeverity} />,
     );
     expect(extension.getByText('All')).toBeTruthy();
     expect(extension.getByText('Severity')).toBeTruthy();

--- a/plugins/policy-reporter/src/components/SelectSeverity/SelectSeverity.tsx
+++ b/plugins/policy-reporter/src/components/SelectSeverity/SelectSeverity.tsx
@@ -1,70 +1,57 @@
-import MenuItem from '@material-ui/core/MenuItem';
-import InputLabel from '@material-ui/core/InputLabel';
-import FormControl from '@material-ui/core/FormControl';
-import Select from '@material-ui/core/Select';
+import { Select } from '@backstage/ui';
 import { Severity } from '@kyverno/backstage-plugin-policy-reporter-common';
-import { makeStyles } from '@material-ui/core/styles';
-import { Checkbox, ListItemText } from '@material-ui/core';
+import { Key } from 'react';
+import React from 'react';
 
-// This could be moved into the common package if needed in multiple places
-const SEVERITY_VALUES: Severity[] = [
-  'unknown',
-  'low',
-  'medium',
-  'high',
-  'critical',
-  'info',
+const SEVERITY_OPTIONS: { value: Severity; label: string }[] = [
+  { value: 'unknown', label: 'Unknown' },
+  { value: 'low', label: 'Low' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'high', label: 'High' },
+  { value: 'critical', label: 'Critical' },
+  { value: 'info', label: 'Info' },
 ];
 
-const useStyles = makeStyles({
-  formControl: {
-    margin: 8,
-    minWidth: 150,
-  },
-});
+const validSeverities = SEVERITY_OPTIONS.map(option => option.value);
 
 export type SelectSeverityProps = {
-  currentSeverity: Severity[];
+  initialSeverity?: Severity[] | Severity;
   setSeverity: (Status: Severity[]) => void;
 };
 
 export const SelectSeverity = ({
-  currentSeverity: currentSeverity,
-  setSeverity: setSeverity,
+  initialSeverity,
+  setSeverity,
 }: SelectSeverityProps) => {
-  const classes = useStyles();
+  const handleChange = (key: Key | Key[] | null) => {
+    if (key === null) {
+      setSeverity([]);
+      return;
+    }
 
-  const handleChange = (event: React.ChangeEvent<{ value: unknown }>) => {
-    setSeverity(event.target.value as Severity[]);
+    if (!Array.isArray(key)) {
+      setSeverity(
+        validSeverities.includes(key as Severity) ? [key as Severity] : [],
+      );
+      return;
+    }
+
+    // Input is an array - filter and validate
+    const filteredStatuses = key.filter((item): item is Severity =>
+      validSeverities.includes(item as Severity),
+    );
+    setSeverity(filteredStatuses);
   };
 
   return (
-    <FormControl className={classes.formControl}>
-      <InputLabel id="select-severity-label" shrink>
-        Severity
-      </InputLabel>
-      <Select
-        labelId="select-severity-label"
-        id="select-severity"
-        multiple
-        displayEmpty
-        value={currentSeverity}
-        renderValue={selected => {
-          if ((selected as Severity[]).length === 0) {
-            return 'All';
-          }
-
-          return (selected as Severity[]).join(', ');
-        }}
-        onChange={handleChange}
-      >
-        {SEVERITY_VALUES.map(severity => (
-          <MenuItem key={severity} value={severity}>
-            <Checkbox checked={currentSeverity.includes(severity)} />
-            <ListItemText primary={severity} />
-          </MenuItem>
-        ))}
-      </Select>
-    </FormControl>
+    <Select
+      label="Severity"
+      selectionMode="multiple"
+      options={SEVERITY_OPTIONS}
+      defaultValue={initialSeverity}
+      onChange={handleChange}
+      placeholder="All"
+      style={{ width: 200 }}
+    />
   );
 };

--- a/plugins/policy-reporter/src/components/SelectSeverity/SelectSeverity.tsx
+++ b/plugins/policy-reporter/src/components/SelectSeverity/SelectSeverity.tsx
@@ -1,7 +1,6 @@
 import { Select } from '@backstage/ui';
 import { Severity } from '@kyverno/backstage-plugin-policy-reporter-common';
 import { Key } from 'react';
-import React from 'react';
 
 const SEVERITY_OPTIONS: { value: Severity; label: string }[] = [
   { value: 'unknown', label: 'Unknown' },

--- a/plugins/policy-reporter/src/components/SelectStatus/SelectStatus.test.tsx
+++ b/plugins/policy-reporter/src/components/SelectStatus/SelectStatus.test.tsx
@@ -6,26 +6,27 @@ const setCurrentStatus = jest.fn();
 describe('SelectStatus', () => {
   it('should render the selected environment', async () => {
     const extension = await renderInTestApp(
-      <SelectStatus currentStatus={['fail']} setStatus={setCurrentStatus} />,
+      <SelectStatus initialStatus={['fail']} setStatus={setCurrentStatus} />,
     );
-    expect(extension.getByText('fail')).toBeTruthy();
+    expect(extension.getAllByText('Fail')).toBeTruthy();
     expect(extension.getByText('Status')).toBeTruthy();
   });
 
   it('should render the selected environments', async () => {
     const extension = await renderInTestApp(
       <SelectStatus
-        currentStatus={['fail', 'summary']}
+        initialStatus={['fail', 'summary']}
         setStatus={setCurrentStatus}
       />,
     );
-    expect(extension.getByText('fail, summary')).toBeTruthy();
+    expect(extension.getAllByText('Fail')).toBeTruthy();
+    expect(extension.getAllByText('Summary')).toBeTruthy();
     expect(extension.getByText('Status')).toBeTruthy();
   });
 
   it('should render all when nothing is selected', async () => {
     const extension = await renderInTestApp(
-      <SelectStatus currentStatus={[]} setStatus={setCurrentStatus} />,
+      <SelectStatus initialStatus={[]} setStatus={setCurrentStatus} />,
     );
     expect(extension.getByText('All')).toBeTruthy();
     expect(extension.getByText('Status')).toBeTruthy();

--- a/plugins/policy-reporter/src/components/SelectStatus/SelectStatus.tsx
+++ b/plugins/policy-reporter/src/components/SelectStatus/SelectStatus.tsx
@@ -1,70 +1,54 @@
-import MenuItem from '@material-ui/core/MenuItem';
-import InputLabel from '@material-ui/core/InputLabel';
-import FormControl from '@material-ui/core/FormControl';
-import Select from '@material-ui/core/Select';
 import { Status } from '@kyverno/backstage-plugin-policy-reporter-common';
-import { makeStyles } from '@material-ui/core/styles';
-import { Checkbox, ListItemText } from '@material-ui/core';
+import { Select } from '@backstage/ui';
+import { Key } from 'react';
 
-// This could be moved into the common package if needed in multiple places
-const STATUS_VALUES: Status[] = [
-  'fail',
-  'skip',
-  'pass',
-  'warn',
-  'error',
-  'summary',
+const STATUS_OPTIONS: { value: Status; label: string }[] = [
+  { value: 'fail', label: 'Fail' },
+  { value: 'skip', label: 'Skip' },
+  { value: 'pass', label: 'Pass' },
+  { value: 'warn', label: 'Warn' },
+  { value: 'error', label: 'Error' },
+  { value: 'summary', label: 'Summary' },
 ];
 
-const useStyles = makeStyles({
-  formControl: {
-    margin: 8,
-    minWidth: 150,
-  },
-});
+const validStatuses = STATUS_OPTIONS.map(option => option.value);
 
 export type SelectStatusProps = {
-  currentStatus: Status[];
+  initialStatus?: Status[] | Status;
   setStatus: (Status: Status[]) => void;
 };
 
 export const SelectStatus = ({
-  currentStatus,
+  initialStatus,
   setStatus,
 }: SelectStatusProps) => {
-  const classes = useStyles();
+  const handleChange = (key: Key | Key[] | null) => {
+    if (key === null) {
+      setStatus([]);
+      return;
+    }
 
-  const handleChange = (event: React.ChangeEvent<{ value: unknown }>) => {
-    setStatus(event.target.value as Status[]);
+    if (!Array.isArray(key)) {
+      setStatus(validStatuses.includes(key as Status) ? [key as Status] : []);
+      return;
+    }
+
+    // Input is an array - filter and validate
+    const filteredStatuses = key.filter((item): item is Status =>
+      validStatuses.includes(item as Status),
+    );
+    setStatus(filteredStatuses);
   };
 
   return (
-    <FormControl className={classes.formControl}>
-      <InputLabel id="select-status-label" shrink>
-        Status
-      </InputLabel>
-      <Select
-        labelId="select-status-label"
-        id="select-status"
-        multiple
-        displayEmpty
-        value={currentStatus}
-        renderValue={selected => {
-          if ((selected as Status[]).length === 0) {
-            return 'All';
-          }
-
-          return (selected as Status[]).join(', ');
-        }}
-        onChange={handleChange}
-      >
-        {STATUS_VALUES.map(status => (
-          <MenuItem key={status} value={status}>
-            <Checkbox checked={currentStatus.includes(status)} />
-            <ListItemText primary={status} />
-          </MenuItem>
-        ))}
-      </Select>
-    </FormControl>
+    <Select
+      label="Status"
+      selectionMode="multiple"
+      options={STATUS_OPTIONS}
+      defaultValue={initialStatus}
+      onChange={handleChange}
+      placeholder="All"
+      style={{ width: 200 }}
+    />
   );
 };

--- a/plugins/policy-reporter/src/components/SeverityComponent/SeverityComponent.tsx
+++ b/plugins/policy-reporter/src/components/SeverityComponent/SeverityComponent.tsx
@@ -1,44 +1,24 @@
-import Chip from '@material-ui/core/Chip';
+import { Tag, TagGroup } from '@backstage/ui';
 import { Severity } from '@kyverno/backstage-plugin-policy-reporter-common';
-import makeStyles from '@material-ui/core/styles/makeStyles';
-
-const useStyles = makeStyles((theme: any) => ({
-  error: {
-    backgroundColor: theme.palette.error.main,
-    color: theme.palette.error.contrastText,
-  },
-  success: {
-    backgroundColor: theme.palette.success.main,
-    color: theme.palette.success.contrastText,
-  },
-  warning: {
-    backgroundColor: theme.palette.warning.main,
-    color: theme.palette.warning.contrastText,
-  },
-  info: {
-    backgroundColor: theme.palette.info.main,
-    color: theme.palette.info.contrastText,
-  },
-}));
 
 type SeverityComponentProps = {
   severity: Severity | null;
 };
 
+const severityStyles: Record<string, React.CSSProperties> = {
+  high: { backgroundColor: 'var(--bui-bg-danger)' },
+  critical: { backgroundColor: 'var(--bui-bg-danger)' },
+  medium: { backgroundColor: 'var(--bui-bg-warning)' },
+  low: { backgroundColor: 'var(--bui-bg-success)' },
+  info: { backgroundColor: 'var(--bui-bg-info)' },
+  unknown: {},
+};
+
 export const SeverityComponent = ({ severity }: SeverityComponentProps) => {
-  const classes = useStyles();
-  switch (severity) {
-    case 'high':
-      return <Chip label={severity} className={classes.error} />;
-    case 'low':
-      return <Chip label={severity} className={classes.success} />;
-    case 'medium':
-      return <Chip label={severity} className={classes.warning} />;
-    case 'info':
-      return <Chip label={severity} className={classes.info} />;
-    case 'critical':
-      return <Chip label={severity} className={classes.error} />;
-    default:
-      return null;
-  }
+  if (!severity) return null;
+  return (
+    <TagGroup>
+      <Tag style={severityStyles[severity]}>{severity}</Tag>
+    </TagGroup>
+  );
 };


### PR DESCRIPTION
This PR migrates more components to make use of the new BUI Design System. 

This does however remove support for providing subtitle to the policy reports page. This would be added back after updating to the next BUI release where Header component gets support for subtitle.

## Screenshot 

<img width="1262" height="1259" alt="image" src="https://github.com/user-attachments/assets/ce75c64c-83f1-4eb6-a0c9-3797eada2a0b" />
