### PR TITLE
feat(url): use url query params for filter state

### DIFF
--- a/.changeset/filter-url-query-params.md
+++ b/.changeset/filter-url-query-params.md
@@ -1,0 +1,5 @@
+---
+'@kyverno/backstage-plugin-policy-reporter': minor
+---
+
+Filter state (search, namespace, severity, and status) is now managed via URL query params, making filter selections shareable and persistent across page refreshes.

--- a/.changeset/slimy-wings-unite.md
+++ b/.changeset/slimy-wings-unite.md
@@ -4,6 +4,6 @@
 
 Entity content pages (`EntityKyvernoPoliciesContent`, `EntityCustomPoliciesContent`) now display a single unified table instead of separate tables for failing/passing/skipped policies, aligning with the `PolicyReportsPage`.
 
-Search state is now managed via URL query params (`?search=`), making search results shareable and persistent across page refreshes.
+Search state is now managed via URL query params, making search results shareable and persistent across page refreshes.
 
 Migrated table component to the new Backstage UI (BUI) components.

--- a/plugins/policy-reporter/package.json
+++ b/plugins/policy-reporter/package.json
@@ -66,6 +66,7 @@
     "@material-ui/core": "^4.12.4",
     "@material-ui/icons": "^4.11.3",
     "@material-ui/lab": "4.0.0-alpha.61",
+    "qs": "^6.15.0",
     "react-use": "^17.6.0"
   },
   "peerDependencies": {
@@ -80,6 +81,7 @@
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.0.0",
+    "@types/qs": "^6.15.0",
     "msw": "^1.0.0"
   },
   "files": [

--- a/plugins/policy-reporter/src/components/EntityCustomPoliciesContent/EntityCustomPoliciesContent.tsx
+++ b/plugins/policy-reporter/src/components/EntityCustomPoliciesContent/EntityCustomPoliciesContent.tsx
@@ -16,6 +16,7 @@ import {
 } from '../../utils/annotations';
 import { MissingEnvironmentsEmptyState } from '../MissingEnvironmentsEmptyState';
 import { useEntityEnvironment } from '../../hooks/useEntityEnvironment';
+import { useFilterParams } from '../../hooks/useFilterParams';
 import { KYVERNO_RESOURCE_NAME_ANNOTATION } from '@kyverno/backstage-plugin-policy-reporter-common';
 
 type EntityCustomPoliciesContentProps = {
@@ -39,6 +40,8 @@ export const EntityCustomPoliciesContent = ({
   const resourceName = getResourceName(annotations);
 
   const annotationsState = isPolicyReporterAvailable(entity);
+
+  useFilterParams({ namespaces, kinds, sources });
 
   const {
     environments,
@@ -100,11 +103,6 @@ export const EntityCustomPoliciesContent = ({
         <Grid.Root columns="1" gap="4">
           <PolicyReportsTable
             currentEnvironment={currentEnvironment}
-            filter={{
-              namespaces,
-              sources,
-              kinds,
-            }}
             emptyContentText="No policies"
             policyDocumentationUrl={policyDocumentationUrl}
           />

--- a/plugins/policy-reporter/src/components/EntityKyvernoPoliciesContent/EntityKyvernoPoliciesContent.tsx
+++ b/plugins/policy-reporter/src/components/EntityKyvernoPoliciesContent/EntityKyvernoPoliciesContent.tsx
@@ -16,6 +16,7 @@ import {
 } from '../../utils/annotations';
 import { MissingEnvironmentsEmptyState } from '../MissingEnvironmentsEmptyState';
 import { useEntityEnvironment } from '../../hooks/useEntityEnvironment';
+import { useFilterParams } from '../../hooks/useFilterParams';
 import { KYVERNO_RESOURCE_NAME_ANNOTATION } from '@kyverno/backstage-plugin-policy-reporter-common';
 
 type KyvernoPoliciesContentProps = {
@@ -43,6 +44,8 @@ export const EntityKyvernoPoliciesContent = ({
   const namespaces = getNamespaces(annotations);
   const kinds = getKinds(annotations);
   const resourceName = getResourceName(annotations);
+
+  useFilterParams({ namespaces, kinds, sources: ['kyverno'] });
 
   const [searchParams, setSearchParams] = useSearchParams();
 
@@ -97,11 +100,6 @@ export const EntityKyvernoPoliciesContent = ({
         <Grid.Root columns="1" gap="4">
           <PolicyReportsTable
             currentEnvironment={currentEnvironment}
-            filter={{
-              namespaces,
-              sources: ['kyverno'],
-              kinds,
-            }}
             emptyContentText="No policies found"
             policyDocumentationUrl={policyDocumentationUrl}
           />

--- a/plugins/policy-reporter/src/components/EntityKyvernoPoliciesContent/EntityKyvernoPoliciesContent.tsx
+++ b/plugins/policy-reporter/src/components/EntityKyvernoPoliciesContent/EntityKyvernoPoliciesContent.tsx
@@ -20,12 +20,10 @@ import { KYVERNO_RESOURCE_NAME_ANNOTATION } from '@kyverno/backstage-plugin-poli
 
 type KyvernoPoliciesContentProps = {
   annotationsDocumentationUrl?: string;
-  policyDocumentationUrl?: string;
 };
 
 export const EntityKyvernoPoliciesContent = ({
   annotationsDocumentationUrl,
-  policyDocumentationUrl,
 }: KyvernoPoliciesContentProps) => {
   const { entity } = useEntity();
   const annotations = entity.metadata.annotations;

--- a/plugins/policy-reporter/src/components/EntityKyvernoPoliciesContent/EntityKyvernoPoliciesContent.tsx
+++ b/plugins/policy-reporter/src/components/EntityKyvernoPoliciesContent/EntityKyvernoPoliciesContent.tsx
@@ -20,10 +20,12 @@ import { KYVERNO_RESOURCE_NAME_ANNOTATION } from '@kyverno/backstage-plugin-poli
 
 type KyvernoPoliciesContentProps = {
   annotationsDocumentationUrl?: string;
+  policyDocumentationUrl?: string;
 };
 
 export const EntityKyvernoPoliciesContent = ({
   annotationsDocumentationUrl,
+  policyDocumentationUrl,
 }: KyvernoPoliciesContentProps) => {
   const { entity } = useEntity();
   const annotations = entity.metadata.annotations;

--- a/plugins/policy-reporter/src/components/PolicyReportsPage/PolicyReportsPage.tsx
+++ b/plugins/policy-reporter/src/components/PolicyReportsPage/PolicyReportsPage.tsx
@@ -23,7 +23,6 @@ import { SearchField } from '../SearchField';
 
 export interface PolicyReportsPageProps {
   title?: string;
-  policyDocumentationUrl?: string;
   subtitle?: string;
 }
 

--- a/plugins/policy-reporter/src/components/PolicyReportsPage/PolicyReportsPage.tsx
+++ b/plugins/policy-reporter/src/components/PolicyReportsPage/PolicyReportsPage.tsx
@@ -23,6 +23,7 @@ import { SearchField } from '../SearchField';
 
 export interface PolicyReportsPageProps {
   title?: string;
+  policyDocumentationUrl?: string;
   subtitle?: string;
 }
 

--- a/plugins/policy-reporter/src/components/PolicyReportsPage/PolicyReportsPage.tsx
+++ b/plugins/policy-reporter/src/components/PolicyReportsPage/PolicyReportsPage.tsx
@@ -92,23 +92,15 @@ export const PolicyReportsPage = ({
       <Content>
         <Grid.Root columns="1" gap="4">
           <Flex align="end" gap="4">
-            <SelectStatus initialStatus="fail" setStatus={setStatus} />
-            <SelectSeverity setSeverity={setSeverity} />
-            <SelectNamespace
-              setNamespaces={setSelectedNamespaces}
-              availableNamespaces={availableNamespaces}
-            />
+            <SelectStatus initialStatus={['fail']} />
+            <SelectSeverity />
+            <SelectNamespace availableNamespaces={availableNamespaces} />
             <Box width="300px" style={{ flexShrink: 0 }}>
               <SearchField />
             </Box>
           </Flex>
           <PolicyReportsTable
             currentEnvironment={currentEnvironment}
-            filter={{
-              status: status,
-              severities: severity,
-              namespaces: selectedNamespaces,
-            }}
             emptyContentText="No policies found"
             policyDocumentationUrl={policyDocumentationUrl}
           />

--- a/plugins/policy-reporter/src/components/PolicyReportsPage/PolicyReportsPage.tsx
+++ b/plugins/policy-reporter/src/components/PolicyReportsPage/PolicyReportsPage.tsx
@@ -10,11 +10,6 @@ import {
 import { useEnvironments } from '../../hooks/useEnvironments';
 import { SelectEnvironment } from '../SelectEnvironment';
 import { PolicyReportsTable } from '../PolicyReportsTable';
-import { useState } from 'react';
-import {
-  Severity,
-  Status,
-} from '@kyverno/backstage-plugin-policy-reporter-common';
 import { SelectStatus } from '../SelectStatus';
 import { SelectSeverity } from '../SelectSeverity';
 import { SelectNamespace } from '../SelectNamespace';
@@ -38,9 +33,6 @@ export const PolicyReportsPage = ({
     currentEnvironment,
   } = useEnvironments();
 
-  const [status, setStatus] = useState<Status[]>(['fail']);
-  const [severity, setSeverity] = useState<Severity[]>([]);
-  const [selectedNamespaces, setSelectedNamespaces] = useState<string[]>([]);
   const { namespaces: availableNamespaces } = useNamespaces(currentEnvironment);
 
   // Fetching environments

--- a/plugins/policy-reporter/src/components/PolicyReportsTable/PolicyReportsTable.test.tsx
+++ b/plugins/policy-reporter/src/components/PolicyReportsTable/PolicyReportsTable.test.tsx
@@ -54,7 +54,6 @@ describe('KyvernoPolicyReportsTable', () => {
             name: 'dev',
             entityRef: 'resource:default/dev',
           }}
-          filter={{}}
           emptyContentText="empty"
         />
         ,
@@ -84,7 +83,6 @@ describe('KyvernoPolicyReportsTable', () => {
             name: 'dev',
             entityRef: 'resource:default/dev',
           }}
-          filter={{}}
           emptyContentText="there are no policies"
         />
         ,
@@ -117,7 +115,6 @@ describe('KyvernoPolicyReportsTable', () => {
             name: 'dev',
             entityRef: 'resource:default/dev',
           }}
-          filter={{}}
           emptyContentText="empty"
         />
         ,
@@ -145,7 +142,6 @@ describe('KyvernoPolicyReportsTable', () => {
             name: 'dev',
             entityRef: 'resource:default/dev',
           }}
-          filter={{}}
           emptyContentText="there are no policies"
         />
         ,
@@ -190,7 +186,6 @@ describe('KyvernoPolicyReportsTable', () => {
             name: 'dev',
             entityRef: 'resource:default/dev',
           }}
-          filter={{}}
           emptyContentText="empty"
         />
         ,

--- a/plugins/policy-reporter/src/components/PolicyReportsTable/PolicyReportsTable.tsx
+++ b/plugins/policy-reporter/src/components/PolicyReportsTable/PolicyReportsTable.tsx
@@ -1,5 +1,4 @@
-import { useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useMemo, useState } from 'react';
 import {
   Filter,
   ListResult,
@@ -20,6 +19,7 @@ import {
 } from '@backstage/ui';
 import { useApi } from '@backstage/frontend-plugin-api';
 import { policyReporterApiRef } from '../../api';
+import { useFilterParams } from '../../hooks/useFilterParams';
 
 interface PolicyReportsTableProps {
   currentEnvironment: Environment;
@@ -35,17 +35,26 @@ export const PolicyReportsTable = ({
   policyDocumentationUrl,
 }: PolicyReportsTableProps) => {
   const policyReporterApi = useApi(policyReporterApiRef);
-  const [searchParams] = useSearchParams();
-  const searchValue = searchParams.get('search') ?? '';
+  const { filter: urlFilter } = useFilterParams();
+
+  // Separate search (used by useTable) from the rest of the URL filter fields.
+  // Long term: all Filter properties live in urlFilter, and the `filter` prop can be removed.
+  const { search: urlSearch, ...urlFilterRest } = urlFilter;
+
+  const mergedFilter = useMemo(
+    () => ({ ...filter, ...urlFilterRest }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [JSON.stringify(filter), JSON.stringify(urlFilterRest)],
+  );
 
   const [drawerContent, setDrawerContent] = useState<ListResult | undefined>(
     undefined,
   );
 
   const { tableProps } = useTable({
-    filter: filter,
+    filter: mergedFilter,
     mode: 'offset',
-    search: searchValue,
+    search: urlSearch ?? '',
     getData: async ({
       offset,
       pageSize,
@@ -171,8 +180,8 @@ export const PolicyReportsTable = ({
           onClick: item => setDrawerContent(item),
         }}
         emptyState={
-          searchValue ? (
-            <Text>No results match "{searchValue}"</Text>
+          urlSearch ? (
+            <Text>No results match "{urlSearch}"</Text>
           ) : (
             <Text>{emptyContentText}</Text>
           )

--- a/plugins/policy-reporter/src/components/PolicyReportsTable/PolicyReportsTable.tsx
+++ b/plugins/policy-reporter/src/components/PolicyReportsTable/PolicyReportsTable.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { ListResult } from '@kyverno/backstage-plugin-policy-reporter-common';
 import { Drawer } from '@material-ui/core';
 import { StatusComponent } from '../StatusComponent';
@@ -31,7 +31,13 @@ export const PolicyReportsTable = ({
 }: PolicyReportsTableProps) => {
   const policyReporterApi = useApi(policyReporterApiRef);
   const { filter: urlFilter, loading } = useFilterParams();
-  const { search, ...filter } = urlFilter;
+  // Memoize to avoid a new object reference on every render (which would cause
+  // useTable to treat it as a changed dependency and re-fetch continuously).
+  const filter = useMemo(() => {
+    const { search: _, ...rest } = urlFilter;
+    return rest;
+  }, [urlFilter]);
+  const search = urlFilter.search;
 
   const [drawerContent, setDrawerContent] = useState<ListResult | undefined>(
     undefined,

--- a/plugins/policy-reporter/src/components/PolicyReportsTable/PolicyReportsTable.tsx
+++ b/plugins/policy-reporter/src/components/PolicyReportsTable/PolicyReportsTable.tsx
@@ -166,22 +166,6 @@ export const PolicyReportsTable = ({
       >
         <PolicyReportsDrawerComponent content={drawerContent} />
       </Drawer>
-      {/* <SearchField */}
-      {/*   size="small" */}
-      {/*   aria-label="Search" */}
-      {/*   placeholder="Search..." */}
-      {/*   {...search} */}
-      {/* /> */}
-
-      {enableSearch && (
-        <SearchField
-          aria-label="Search"
-          label="Search"
-          value={search.value}
-          onChange={search.onChange}
-          style={{ width: '350px' }}
-        />
-      )}
       <Table
         rowConfig={{
           onClick: item => setDrawerContent(item),

--- a/plugins/policy-reporter/src/components/PolicyReportsTable/PolicyReportsTable.tsx
+++ b/plugins/policy-reporter/src/components/PolicyReportsTable/PolicyReportsTable.tsx
@@ -166,6 +166,22 @@ export const PolicyReportsTable = ({
       >
         <PolicyReportsDrawerComponent content={drawerContent} />
       </Drawer>
+      {/* <SearchField */}
+      {/*   size="small" */}
+      {/*   aria-label="Search" */}
+      {/*   placeholder="Search..." */}
+      {/*   {...search} */}
+      {/* /> */}
+
+      {enableSearch && (
+        <SearchField
+          aria-label="Search"
+          label="Search"
+          value={search.value}
+          onChange={search.onChange}
+          style={{ width: '350px' }}
+        />
+      )}
       <Table
         rowConfig={{
           onClick: item => setDrawerContent(item),

--- a/plugins/policy-reporter/src/components/PolicyReportsTable/PolicyReportsTable.tsx
+++ b/plugins/policy-reporter/src/components/PolicyReportsTable/PolicyReportsTable.tsx
@@ -1,8 +1,5 @@
-import { useMemo, useState } from 'react';
-import {
-  Filter,
-  ListResult,
-} from '@kyverno/backstage-plugin-policy-reporter-common';
+import { useState } from 'react';
+import { ListResult } from '@kyverno/backstage-plugin-policy-reporter-common';
 import { Drawer } from '@material-ui/core';
 import { StatusComponent } from '../StatusComponent';
 import { SeverityComponent } from '../SeverityComponent';
@@ -23,7 +20,6 @@ import { useFilterParams } from '../../hooks/useFilterParams';
 
 interface PolicyReportsTableProps {
   currentEnvironment: Environment;
-  filter: Filter;
   emptyContentText: string;
   policyDocumentationUrl?: string;
 }
@@ -31,30 +27,20 @@ interface PolicyReportsTableProps {
 export const PolicyReportsTable = ({
   emptyContentText,
   currentEnvironment,
-  filter,
   policyDocumentationUrl,
 }: PolicyReportsTableProps) => {
   const policyReporterApi = useApi(policyReporterApiRef);
-  const { filter: urlFilter } = useFilterParams();
-
-  // Separate search (used by useTable) from the rest of the URL filter fields.
-  // Long term: all Filter properties live in urlFilter, and the `filter` prop can be removed.
-  const { search: urlSearch, ...urlFilterRest } = urlFilter;
-
-  const mergedFilter = useMemo(
-    () => ({ ...filter, ...urlFilterRest }),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [JSON.stringify(filter), JSON.stringify(urlFilterRest)],
-  );
+  const { filter: urlFilter, loading } = useFilterParams();
+  const { search, ...filter } = urlFilter;
 
   const [drawerContent, setDrawerContent] = useState<ListResult | undefined>(
     undefined,
   );
 
   const { tableProps } = useTable({
-    filter: mergedFilter,
+    filter: filter,
     mode: 'offset',
-    search: urlSearch ?? '',
+    search: search,
     getData: async ({
       offset,
       pageSize,
@@ -176,12 +162,13 @@ export const PolicyReportsTable = ({
         <PolicyReportsDrawerComponent content={drawerContent} />
       </Drawer>
       <Table
+        loading={loading}
         rowConfig={{
           onClick: item => setDrawerContent(item),
         }}
         emptyState={
-          urlSearch ? (
-            <Text>No results match "{urlSearch}"</Text>
+          search ? (
+            <Text>No results match "{search}"</Text>
           ) : (
             <Text>{emptyContentText}</Text>
           )

--- a/plugins/policy-reporter/src/components/SearchField/SearchField.tsx
+++ b/plugins/policy-reporter/src/components/SearchField/SearchField.tsx
@@ -1,23 +1,18 @@
 import { useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
 import { useDebounce } from 'react-use';
 import { SearchField as BackstageSearchField } from '@backstage/ui';
+import { useFilterParams } from '../../hooks/useFilterParams';
 
 export const SearchField = () => {
-  const [searchParams, setSearchParams] = useSearchParams();
-  const [inputValue, setInputValue] = useState(
-    searchParams.get('search') ?? '',
-  );
+  const { filter, setFilter } = useFilterParams();
+  const [inputValue, setInputValue] = useState(filter.search ?? '');
 
   useDebounce(
     () => {
-      const newParams = new URLSearchParams(searchParams);
-      if (inputValue) {
-        newParams.set('search', inputValue);
-      } else {
-        newParams.delete('search');
-      }
-      setSearchParams(newParams, { replace: true });
+      setFilter(prev => ({
+        ...prev,
+        search: inputValue || undefined,
+      }));
     },
     300,
     [inputValue],

--- a/plugins/policy-reporter/src/components/SearchField/SearchField.tsx
+++ b/plugins/policy-reporter/src/components/SearchField/SearchField.tsx
@@ -1,22 +1,23 @@
 import { useState } from 'react';
 import { useDebounce } from 'react-use';
-import { SearchField as BackstageSearchField } from '@backstage/ui';
+import { SearchField as BackstageSearchField, Skeleton } from '@backstage/ui';
 import { useFilterParams } from '../../hooks/useFilterParams';
 
 export const SearchField = () => {
-  const { filter, setFilter } = useFilterParams();
+  const { filter, updateFilter, loading } = useFilterParams();
   const [inputValue, setInputValue] = useState(filter.search ?? '');
 
   useDebounce(
     () => {
-      setFilter(prev => ({
-        ...prev,
+      updateFilter({
         search: inputValue || undefined,
-      }));
+      });
     },
     300,
     [inputValue],
   );
+
+  if (loading) return <Skeleton width={350} height={24} />;
 
   return (
     <BackstageSearchField

--- a/plugins/policy-reporter/src/components/SelectNamespace/SelectNamespace.test.tsx
+++ b/plugins/policy-reporter/src/components/SelectNamespace/SelectNamespace.test.tsx
@@ -1,7 +1,6 @@
 import { renderInTestApp } from '@backstage/test-utils';
 import { SelectNamespace } from './SelectNamespace';
 
-const setNamespaces = jest.fn();
 const availableNamespaces = ['default', 'kube-system'];
 
 describe('SelectNamespace', () => {
@@ -9,7 +8,6 @@ describe('SelectNamespace', () => {
     const extension = await renderInTestApp(
       <SelectNamespace
         initialNamespaces={['default']}
-        setNamespaces={setNamespaces}
         availableNamespaces={availableNamespaces}
       />,
     );
@@ -21,7 +19,6 @@ describe('SelectNamespace', () => {
     const extension = await renderInTestApp(
       <SelectNamespace
         initialNamespaces={['default', 'kube-system']}
-        setNamespaces={setNamespaces}
         availableNamespaces={availableNamespaces}
       />,
     );
@@ -32,10 +29,7 @@ describe('SelectNamespace', () => {
 
   it('should render all when nothing is selected', async () => {
     const extension = await renderInTestApp(
-      <SelectNamespace
-        setNamespaces={setNamespaces}
-        availableNamespaces={availableNamespaces}
-      />,
+      <SelectNamespace availableNamespaces={availableNamespaces} />,
     );
     expect(extension.getByText('All')).toBeTruthy();
     expect(extension.getByText('Namespace')).toBeTruthy();

--- a/plugins/policy-reporter/src/components/SelectNamespace/SelectNamespace.tsx
+++ b/plugins/policy-reporter/src/components/SelectNamespace/SelectNamespace.tsx
@@ -1,44 +1,51 @@
-import { Select } from '@backstage/ui';
+import { Select, Skeleton } from '@backstage/ui';
 import { Key } from 'react';
+import { useFilterParams } from '../../hooks/useFilterParams';
 
 export type SelectNamespaceProps = {
   initialNamespaces?: string[];
-  setNamespaces: (namespaces: string[]) => void;
   availableNamespaces: string[];
 };
 
 export const SelectNamespace = ({
   initialNamespaces,
-  setNamespaces,
   availableNamespaces,
 }: SelectNamespaceProps) => {
+  const { updateFilter, filter, loading } = useFilterParams({
+    namespaces: initialNamespaces,
+  });
+
   const options = availableNamespaces.map(ns => ({ value: ns, label: ns }));
 
   const handleChange = (key: Key | Key[] | null) => {
     if (key === null) {
-      setNamespaces([]);
+      updateFilter({ namespaces: [] });
       return;
     }
 
     if (!Array.isArray(key)) {
-      setNamespaces(
-        availableNamespaces.includes(key as string) ? [key as string] : [],
-      );
+      updateFilter({
+        namespaces: availableNamespaces.includes(key as string)
+          ? [key as string]
+          : [],
+      });
       return;
     }
 
     const filtered = key.filter((item): item is string =>
       availableNamespaces.includes(item as string),
     );
-    setNamespaces(filtered);
+    updateFilter({ namespaces: filtered });
   };
+
+  if (loading) return <Skeleton width={200} height={24} />;
 
   return (
     <Select
       label="Namespace"
       selectionMode="multiple"
       options={options}
-      defaultValue={initialNamespaces}
+      defaultValue={filter.namespaces}
       onChange={handleChange}
       placeholder="All"
       style={{ width: 200 }}

--- a/plugins/policy-reporter/src/components/SelectSeverity/SelectSeverity.test.tsx
+++ b/plugins/policy-reporter/src/components/SelectSeverity/SelectSeverity.test.tsx
@@ -1,15 +1,10 @@
 import { renderInTestApp } from '@backstage/test-utils';
 import { SelectSeverity } from './SelectSeverity';
 
-const setCurrentSeverity = jest.fn();
-
 describe('SelectSeverity', () => {
   it('should render the selected environment', async () => {
     const extension = await renderInTestApp(
-      <SelectSeverity
-        initialSeverity={['critical']}
-        setSeverity={setCurrentSeverity}
-      />,
+      <SelectSeverity initialSeverity={['critical']} />,
     );
     expect(extension.getAllByText('Critical')).toBeTruthy();
     expect(extension.getByText('Severity')).toBeTruthy();
@@ -17,10 +12,7 @@ describe('SelectSeverity', () => {
 
   it('should render the selected environments', async () => {
     const extension = await renderInTestApp(
-      <SelectSeverity
-        initialSeverity={['info', 'low']}
-        setSeverity={setCurrentSeverity}
-      />,
+      <SelectSeverity initialSeverity={['info', 'low']} />,
     );
     expect(extension.getAllByText('Info')).toBeTruthy();
     expect(extension.getAllByText('Low')).toBeTruthy();
@@ -29,7 +21,7 @@ describe('SelectSeverity', () => {
 
   it('should render all when nothing is selected', async () => {
     const extension = await renderInTestApp(
-      <SelectSeverity initialSeverity={[]} setSeverity={setCurrentSeverity} />,
+      <SelectSeverity initialSeverity={[]} />,
     );
     expect(extension.getByText('All')).toBeTruthy();
     expect(extension.getByText('Severity')).toBeTruthy();

--- a/plugins/policy-reporter/src/components/SelectSeverity/SelectSeverity.tsx
+++ b/plugins/policy-reporter/src/components/SelectSeverity/SelectSeverity.tsx
@@ -1,6 +1,7 @@
 import { Select, Skeleton } from '@backstage/ui';
 import { Severity } from '@kyverno/backstage-plugin-policy-reporter-common';
 import { Key } from 'react';
+import { useFilterParams } from '../../hooks/useFilterParams';
 
 const SEVERITY_OPTIONS: { value: Severity; label: string }[] = [
   { value: 'unknown', label: 'Unknown' },

--- a/plugins/policy-reporter/src/components/SelectSeverity/SelectSeverity.tsx
+++ b/plugins/policy-reporter/src/components/SelectSeverity/SelectSeverity.tsx
@@ -1,4 +1,4 @@
-import { Select } from '@backstage/ui';
+import { Select, Skeleton } from '@backstage/ui';
 import { Severity } from '@kyverno/backstage-plugin-policy-reporter-common';
 import { Key } from 'react';
 
@@ -14,24 +14,26 @@ const SEVERITY_OPTIONS: { value: Severity; label: string }[] = [
 const validSeverities = SEVERITY_OPTIONS.map(option => option.value);
 
 export type SelectSeverityProps = {
-  initialSeverity?: Severity[] | Severity;
-  setSeverity: (Status: Severity[]) => void;
+  initialSeverity?: Severity[];
 };
 
-export const SelectSeverity = ({
-  initialSeverity,
-  setSeverity,
-}: SelectSeverityProps) => {
+export const SelectSeverity = ({ initialSeverity }: SelectSeverityProps) => {
+  const { updateFilter, filter, loading } = useFilterParams({
+    severities: initialSeverity,
+  });
+
   const handleChange = (key: Key | Key[] | null) => {
     if (key === null) {
-      setSeverity([]);
+      updateFilter({ severities: [] });
       return;
     }
 
     if (!Array.isArray(key)) {
-      setSeverity(
-        validSeverities.includes(key as Severity) ? [key as Severity] : [],
-      );
+      updateFilter({
+        severities: validSeverities.includes(key as Severity)
+          ? [key as Severity]
+          : [],
+      });
       return;
     }
 
@@ -39,15 +41,18 @@ export const SelectSeverity = ({
     const filteredStatuses = key.filter((item): item is Severity =>
       validSeverities.includes(item as Severity),
     );
-    setSeverity(filteredStatuses);
+
+    updateFilter({ severities: filteredStatuses });
   };
+
+  if (loading) return <Skeleton width={200} height={24} />;
 
   return (
     <Select
       label="Severity"
       selectionMode="multiple"
       options={SEVERITY_OPTIONS}
-      defaultValue={initialSeverity}
+      defaultValue={filter.severities}
       onChange={handleChange}
       placeholder="All"
       style={{ width: 200 }}

--- a/plugins/policy-reporter/src/components/SelectStatus/SelectStatus.test.tsx
+++ b/plugins/policy-reporter/src/components/SelectStatus/SelectStatus.test.tsx
@@ -1,12 +1,10 @@
 import { renderInTestApp } from '@backstage/test-utils';
 import { SelectStatus } from './SelectStatus';
 
-const setCurrentStatus = jest.fn();
-
 describe('SelectStatus', () => {
   it('should render the selected environment', async () => {
     const extension = await renderInTestApp(
-      <SelectStatus initialStatus={['fail']} setStatus={setCurrentStatus} />,
+      <SelectStatus initialStatus={['fail']} />,
     );
     expect(extension.getAllByText('Fail')).toBeTruthy();
     expect(extension.getByText('Status')).toBeTruthy();
@@ -14,10 +12,7 @@ describe('SelectStatus', () => {
 
   it('should render the selected environments', async () => {
     const extension = await renderInTestApp(
-      <SelectStatus
-        initialStatus={['fail', 'summary']}
-        setStatus={setCurrentStatus}
-      />,
+      <SelectStatus initialStatus={['fail', 'summary']} />,
     );
     expect(extension.getAllByText('Fail')).toBeTruthy();
     expect(extension.getAllByText('Summary')).toBeTruthy();
@@ -26,7 +21,7 @@ describe('SelectStatus', () => {
 
   it('should render all when nothing is selected', async () => {
     const extension = await renderInTestApp(
-      <SelectStatus initialStatus={[]} setStatus={setCurrentStatus} />,
+      <SelectStatus initialStatus={[]} />,
     );
     expect(extension.getByText('All')).toBeTruthy();
     expect(extension.getByText('Status')).toBeTruthy();

--- a/plugins/policy-reporter/src/components/SelectStatus/SelectStatus.tsx
+++ b/plugins/policy-reporter/src/components/SelectStatus/SelectStatus.tsx
@@ -1,6 +1,7 @@
 import { Status } from '@kyverno/backstage-plugin-policy-reporter-common';
-import { Select } from '@backstage/ui';
+import { Select, Skeleton } from '@backstage/ui';
 import { Key } from 'react';
+import { useFilterParams } from '../../hooks/useFilterParams';
 
 const STATUS_OPTIONS: { value: Status; label: string }[] = [
   { value: 'fail', label: 'Fail' },
@@ -14,22 +15,24 @@ const STATUS_OPTIONS: { value: Status; label: string }[] = [
 const validStatuses = STATUS_OPTIONS.map(option => option.value);
 
 export type SelectStatusProps = {
-  initialStatus?: Status[] | Status;
-  setStatus: (Status: Status[]) => void;
+  initialStatus?: Status[];
 };
 
-export const SelectStatus = ({
-  initialStatus,
-  setStatus,
-}: SelectStatusProps) => {
+export const SelectStatus = ({ initialStatus }: SelectStatusProps) => {
+  const { updateFilter, filter, loading } = useFilterParams({
+    status: initialStatus,
+  });
+
   const handleChange = (key: Key | Key[] | null) => {
     if (key === null) {
-      setStatus([]);
+      updateFilter({ status: [] });
       return;
     }
 
     if (!Array.isArray(key)) {
-      setStatus(validStatuses.includes(key as Status) ? [key as Status] : []);
+      updateFilter({
+        status: validStatuses.includes(key as Status) ? [key as Status] : [],
+      });
       return;
     }
 
@@ -37,15 +40,17 @@ export const SelectStatus = ({
     const filteredStatuses = key.filter((item): item is Status =>
       validStatuses.includes(item as Status),
     );
-    setStatus(filteredStatuses);
+    updateFilter({ status: filteredStatuses });
   };
+
+  if (loading) return <Skeleton width={200} height={35} />;
 
   return (
     <Select
       label="Status"
       selectionMode="multiple"
       options={STATUS_OPTIONS}
-      defaultValue={initialStatus}
+      defaultValue={filter.status}
       onChange={handleChange}
       placeholder="All"
       style={{ width: 200 }}

--- a/plugins/policy-reporter/src/hooks/useFilterParams.ts
+++ b/plugins/policy-reporter/src/hooks/useFilterParams.ts
@@ -32,7 +32,7 @@ const stringifyWithFilter = (
 ): string =>
   qs.stringify(
     { ...parsed, filter: Object.keys(filter).length ? filter : undefined },
-    { arrayFormat: 'brackets', skipNulls: true },
+    { arrayFormat: 'indices', skipNulls: true },
   );
 
 export const useFilterParams = (defaults?: Partial<Filter>) => {

--- a/plugins/policy-reporter/src/hooks/useFilterParams.ts
+++ b/plugins/policy-reporter/src/hooks/useFilterParams.ts
@@ -1,0 +1,41 @@
+import qs from 'qs';
+import { useCallback } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import type { Filter } from '@kyverno/backstage-plugin-policy-reporter-common';
+
+export const useFilterParams = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const filter = (qs.parse(searchParams.toString()).filter ?? {}) as Filter;
+
+  const setFilter = useCallback(
+    (updater: (prev: Filter) => Filter) => {
+      setSearchParams(
+        prev => {
+          const parsed = qs.parse(prev.toString());
+          const next = updater((parsed.filter ?? {}) as Filter);
+          // Drop empty/undefined values so the URL stays clean
+          const clean = Object.fromEntries(
+            Object.entries(next).filter(
+              ([, v]) =>
+                v !== undefined &&
+                v !== '' &&
+                !(Array.isArray(v) && v.length === 0),
+            ),
+          );
+          return qs.stringify(
+            {
+              ...parsed,
+              filter: Object.keys(clean).length ? clean : undefined,
+            },
+            { arrayFormat: 'brackets', skipNulls: true },
+          );
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
+
+  return { filter, setFilter };
+};

--- a/plugins/policy-reporter/src/hooks/useFilterParams.ts
+++ b/plugins/policy-reporter/src/hooks/useFilterParams.ts
@@ -1,35 +1,68 @@
 import qs from 'qs';
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import type { Filter } from '@kyverno/backstage-plugin-policy-reporter-common';
+import { useEffectOnce } from 'react-use';
 
-export const useFilterParams = () => {
+/**
+ * Strips empty, blank, and empty-array values from a filter object so the URL stays clean.
+ *
+ * @param filter - The filter object to clean.
+ * @returns A new filter object with all empty values removed.
+ */
+const cleanFilter = (filter: Partial<Filter>): Partial<Filter> =>
+  Object.fromEntries(
+    Object.entries(filter).filter(
+      ([, v]) =>
+        v !== undefined && v !== '' && !(Array.isArray(v) && v.length === 0),
+    ),
+  );
+
+/**
+ * Serialises the full query-string, merging a cleaned filter into the existing params.
+ * Omits the filter key entirely when empty.
+ *
+ * @param parsed - The currently parsed query-string params.
+ * @param filter - The cleaned filter to merge in.
+ * @returns The serialised query-string.
+ */
+const stringifyWithFilter = (
+  parsed: qs.ParsedQs,
+  filter: Partial<Filter>,
+): string =>
+  qs.stringify(
+    { ...parsed, filter: Object.keys(filter).length ? filter : undefined },
+    { arrayFormat: 'brackets', skipNulls: true },
+  );
+
+export const useFilterParams = (defaults?: Partial<Filter>) => {
   const [searchParams, setSearchParams] = useSearchParams();
+  const [loading, setLoading] = useState(true);
+
+  useEffectOnce(() => {
+    const parsed = qs.parse(searchParams.toString());
+    if (parsed.filter === undefined && defaults) {
+      const clean = cleanFilter(defaults);
+      if (Object.keys(clean).length) {
+        setSearchParams(stringifyWithFilter(parsed, clean), { replace: true });
+      }
+    }
+    setLoading(false);
+  });
 
   const filter = (qs.parse(searchParams.toString()).filter ?? {}) as Filter;
 
-  const setFilter = useCallback(
-    (updater: (prev: Filter) => Filter) => {
+  const updateFilter = useCallback(
+    (filters: Partial<Filter> | ((prevFilters: Filter) => Partial<Filter>)) => {
       setSearchParams(
         prev => {
           const parsed = qs.parse(prev.toString());
-          const next = updater((parsed.filter ?? {}) as Filter);
-          // Drop empty/undefined values so the URL stays clean
-          const clean = Object.fromEntries(
-            Object.entries(next).filter(
-              ([, v]) =>
-                v !== undefined &&
-                v !== '' &&
-                !(Array.isArray(v) && v.length === 0),
-            ),
-          );
-          return qs.stringify(
-            {
-              ...parsed,
-              filter: Object.keys(clean).length ? clean : undefined,
-            },
-            { arrayFormat: 'brackets', skipNulls: true },
-          );
+          const prevFilter = (parsed.filter ?? {}) as Filter;
+          const partial =
+            typeof filters === 'function' ? filters(prevFilter) : filters;
+          const next = { ...prevFilter, ...partial };
+          const clean = cleanFilter(next);
+          return stringifyWithFilter(parsed, clean);
         },
         { replace: true },
       );
@@ -37,5 +70,5 @@ export const useFilterParams = () => {
     [setSearchParams],
   );
 
-  return { filter, setFilter };
+  return { filter, updateFilter, loading };
 };

--- a/plugins/policy-reporter/src/hooks/useFilterParams.ts
+++ b/plugins/policy-reporter/src/hooks/useFilterParams.ts
@@ -1,5 +1,5 @@
 import qs from 'qs';
-import { useCallback, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import type { Filter } from '@kyverno/backstage-plugin-policy-reporter-common';
 import { useEffectOnce } from 'react-use';
@@ -50,7 +50,11 @@ export const useFilterParams = (defaults?: Partial<Filter>) => {
     setLoading(false);
   });
 
-  const filter = (qs.parse(searchParams.toString()).filter ?? {}) as Filter;
+  const searchParamsStr = searchParams.toString();
+  const filter = useMemo(
+    () => (qs.parse(searchParamsStr).filter ?? {}) as Filter,
+    [searchParamsStr],
+  );
 
   const updateFilter = useCallback(
     (filters: Partial<Filter> | ((prevFilters: Filter) => Partial<Filter>)) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5602,7 +5602,9 @@ __metadata:
     "@testing-library/jest-dom": "npm:^6.0.0"
     "@testing-library/react": "npm:^14.0.0"
     "@testing-library/user-event": "npm:^14.0.0"
+    "@types/qs": "npm:^6.15.0"
     msw: "npm:^1.0.0"
+    qs: "npm:^6.15.0"
     react-use: "npm:^17.6.0"
   peerDependencies:
     react: ^16.13.1 || ^17.0.0 || ^18.0.0
@@ -12827,6 +12829,13 @@ __metadata:
   version: 6.9.16
   resolution: "@types/qs@npm:6.9.16"
   checksum: 10c0/a4e871b80fff623755e356fd1f225aea45ff7a29da30f99fddee1a05f4f5f33485b314ab5758145144ed45708f97e44595aa9a8368e9bbc083932f931b12dbb6
+  languageName: node
+  linkType: hard
+
+"@types/qs@npm:^6.15.0":
+  version: 6.15.0
+  resolution: "@types/qs@npm:6.15.0"
+  checksum: 10c0/1b104cac50e655fc41d7fc1de2c2aba2908c4cf833a555b6808fb4c96752662b439238f2392a15d2590a7a6ca75dbd40e42d9378ac2be0d548ee484954363688
   languageName: node
   linkType: hard
 
@@ -28858,6 +28867,15 @@ __metadata:
   dependencies:
     side-channel: "npm:^1.1.0"
   checksum: 10c0/8ea5d91bf34f440598ee389d4a7d95820e3b837d3fd9f433871f7924801becaa0cd3b3b4628d49a7784d06a8aea9bc4554d2b6d8d584e2d221dc06238a42909c
+  languageName: node
+  linkType: hard
+
+"qs@npm:^6.15.0":
+  version: 6.15.0
+  resolution: "qs@npm:6.15.0"
+  dependencies:
+    side-channel: "npm:^1.1.0"
+  checksum: 10c0/ff341078a78a991d8a48b4524d52949211447b4b1ad907f489cac0770cbc346a28e47304455c0320e5fb000f8762d64b03331e3b71865f663bf351bcba8cdb4b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR adds support for using URL query params to store filters

This will also be added to the environment selector to enable deep linking in a future PR.