### PR TITLE
feat(filter): add filter layout component

### DIFF
--- a/.changeset/add-filter-layout-responsive-sidebar.md
+++ b/.changeset/add-filter-layout-responsive-sidebar.md
@@ -1,0 +1,5 @@
+---
+'@kyverno/backstage-plugin-policy-reporter': minor
+---
+
+Add `FilterLayout` component with responsive sidebar filters. On large screens filters render as a sidebar, on smaller screens they collapse into a dialog triggered by a filter icon button. Updated `EntityCustomPoliciesContent`, `EntityKyvernoPoliciesContent`, and `PolicyReportsPage` to use the new layout.

--- a/plugins/policy-reporter/package.json
+++ b/plugins/policy-reporter/package.json
@@ -66,6 +66,7 @@
     "@material-ui/core": "^4.12.4",
     "@material-ui/icons": "^4.11.3",
     "@material-ui/lab": "4.0.0-alpha.61",
+    "@remixicon/react": "^4.9.0",
     "qs": "^6.15.0",
     "react-use": "^17.6.0"
   },

--- a/plugins/policy-reporter/src/components/EntityCustomPoliciesContent/EntityCustomPoliciesContent.tsx
+++ b/plugins/policy-reporter/src/components/EntityCustomPoliciesContent/EntityCustomPoliciesContent.tsx
@@ -3,7 +3,7 @@ import {
   MissingAnnotationEmptyState,
   useEntity,
 } from '@backstage/plugin-catalog-react';
-import { Container, Flex, Grid, Header } from '@backstage/ui';
+import { Container, Header } from '@backstage/ui';
 import { PolicyReportsTable } from '../PolicyReportsTable';
 import { SelectEnvironment } from '../SelectEnvironment';
 import {
@@ -18,6 +18,7 @@ import { PolicyReportsFiltersProvider } from '../../hooks/usePolicyReportsFilter
 import { KYVERNO_RESOURCE_NAME_ANNOTATION } from '@kyverno/backstage-plugin-policy-reporter-common';
 import { SelectStatus } from '../SelectStatus';
 import { SelectSeverity } from '../SelectSeverity';
+import { FilterLayout } from '../FilterLayout';
 
 type EntityCustomPoliciesContentProps = {
   annotationsDocumentationUrl?: string;
@@ -84,16 +85,18 @@ export const EntityCustomPoliciesContent = ({
           customActions={<SelectEnvironment environments={environments} />}
         />
         <Content>
-          <Grid.Root columns="1" gap="4">
-            <Flex align="end" gap="4">
+          <FilterLayout>
+            <FilterLayout.Filters>
               <SelectStatus />
               <SelectSeverity />
-            </Flex>
-            <PolicyReportsTable
-              emptyContentText="No policies"
-              policyDocumentationUrl={policyDocumentationUrl}
-            />
-          </Grid.Root>
+            </FilterLayout.Filters>
+            <FilterLayout.Content>
+              <PolicyReportsTable
+                emptyContentText="No policies"
+                policyDocumentationUrl={policyDocumentationUrl}
+              />
+            </FilterLayout.Content>
+          </FilterLayout>
         </Content>
       </Container>
     </PolicyReportsFiltersProvider>

--- a/plugins/policy-reporter/src/components/EntityKyvernoPoliciesContent/EntityKyvernoPoliciesContent.tsx
+++ b/plugins/policy-reporter/src/components/EntityKyvernoPoliciesContent/EntityKyvernoPoliciesContent.tsx
@@ -3,7 +3,7 @@ import {
   MissingAnnotationEmptyState,
   useEntity,
 } from '@backstage/plugin-catalog-react';
-import { Container, Flex, Grid, Header } from '@backstage/ui';
+import { Container, Header } from '@backstage/ui';
 import { PolicyReportsTable } from '../PolicyReportsTable';
 import { SelectEnvironment } from '../SelectEnvironment';
 import {
@@ -18,6 +18,7 @@ import { PolicyReportsFiltersProvider } from '../../hooks/usePolicyReportsFilter
 import { KYVERNO_RESOURCE_NAME_ANNOTATION } from '@kyverno/backstage-plugin-policy-reporter-common';
 import { SelectSeverity } from '../SelectSeverity';
 import { SelectStatus } from '../SelectStatus';
+import { FilterLayout } from '../FilterLayout';
 
 type KyvernoPoliciesContentProps = {
   annotationsDocumentationUrl?: string;
@@ -80,16 +81,18 @@ export const EntityKyvernoPoliciesContent = ({
           customActions={<SelectEnvironment environments={environments} />}
         />
         <Content>
-          <Grid.Root columns="1" gap="4">
-            <Flex align="end" gap="4">
+          <FilterLayout>
+            <FilterLayout.Filters>
               <SelectStatus />
               <SelectSeverity />
-            </Flex>
-            <PolicyReportsTable
-              emptyContentText="No policies found"
-              policyDocumentationUrl={policyDocumentationUrl}
-            />
-          </Grid.Root>
+            </FilterLayout.Filters>
+            <FilterLayout.Content>
+              <PolicyReportsTable
+                emptyContentText="No policies found"
+                policyDocumentationUrl={policyDocumentationUrl}
+              />
+            </FilterLayout.Content>
+          </FilterLayout>
         </Content>
       </Container>
     </PolicyReportsFiltersProvider>

--- a/plugins/policy-reporter/src/components/FilterLayout/FilterLayout.tsx
+++ b/plugins/policy-reporter/src/components/FilterLayout/FilterLayout.tsx
@@ -31,26 +31,28 @@ const Filters = ({ children, title = 'Filters' }: FiltersProps) => {
 
   if (isSmallScreen) {
     return (
-      <DialogTrigger isOpen={open} onOpenChange={setOpen}>
-        <ButtonIcon
-          variant="secondary"
-          aria-label={title}
-          icon={<RiFilter3Fill />}
-        />
-        <Dialog>
-          <DialogHeader>{title}</DialogHeader>
-          <DialogBody>
-            <Flex direction="column" gap="4">
-              {children}
-            </Flex>
-          </DialogBody>
-        </Dialog>
-      </DialogTrigger>
+      <Grid.Item colSpan="12">
+        <DialogTrigger isOpen={open} onOpenChange={setOpen}>
+          <ButtonIcon
+            variant="secondary"
+            aria-label={title}
+            icon={<RiFilter3Fill />}
+          />
+          <Dialog>
+            <DialogHeader>{title}</DialogHeader>
+            <DialogBody>
+              <Flex direction="column" gap="4">
+                {children}
+              </Flex>
+            </DialogBody>
+          </Dialog>
+        </DialogTrigger>
+      </Grid.Item>
     );
   }
 
   return (
-    <Grid.Item colSpan={{ initial: '12', md: '3', lg: '2' }}>
+    <Grid.Item colSpan={{ initial: '12', lg: '2' }}>
       <Flex direction="column" gap="4">
         <Text weight="bold">{title}</Text>
         {children}
@@ -67,9 +69,7 @@ interface ContentProps {
 /** Main content area that fills remaining grid space */
 const Content = ({ children }: ContentProps) => {
   return (
-    <Grid.Item colSpan={{ initial: '12', md: '9', lg: '10' }}>
-      {children}
-    </Grid.Item>
+    <Grid.Item colSpan={{ initial: '12', lg: '10' }}>{children}</Grid.Item>
   );
 };
 

--- a/plugins/policy-reporter/src/components/FilterLayout/FilterLayout.tsx
+++ b/plugins/policy-reporter/src/components/FilterLayout/FilterLayout.tsx
@@ -54,7 +54,7 @@ const Filters = ({ children, title = 'Filters' }: FiltersProps) => {
   return (
     <Grid.Item colSpan={{ initial: '12', lg: '2' }}>
       <Flex direction="column" gap="4">
-        <Text weight="bold">{title}</Text>
+        <Text variant="title-x-small">{title}</Text>
         {children}
       </Flex>
     </Grid.Item>

--- a/plugins/policy-reporter/src/components/FilterLayout/FilterLayout.tsx
+++ b/plugins/policy-reporter/src/components/FilterLayout/FilterLayout.tsx
@@ -1,0 +1,87 @@
+import { type ReactNode, useState } from 'react';
+import {
+  ButtonIcon,
+  Dialog,
+  DialogBody,
+  DialogHeader,
+  DialogTrigger,
+  Flex,
+  Grid,
+  Text,
+  useBreakpoint,
+} from '@backstage/ui';
+import { RiFilter3Fill } from '@remixicon/react';
+
+/** Props for the Filters sub-component */
+interface FiltersProps {
+  children: ReactNode;
+  /** Label shown in the dialog header on small screens */
+  title?: string;
+}
+
+/** Renders filter children as a sidebar on large screens, or inside a Dialog on smaller screens */
+const Filters = ({ children, title = 'Filters' }: FiltersProps) => {
+  const { down } = useBreakpoint();
+  const isSmallScreen = down('md');
+  const [open, setOpen] = useState(false);
+
+  if (isSmallScreen) {
+    return (
+      <DialogTrigger isOpen={open} onOpenChange={setOpen}>
+        <ButtonIcon
+          variant="secondary"
+          aria-label={title}
+          icon={<RiFilter3Fill />}
+        />
+        <Dialog>
+          <DialogHeader>{title}</DialogHeader>
+          <DialogBody>
+            <Flex direction="column" gap="4">
+              {children}
+            </Flex>
+          </DialogBody>
+        </Dialog>
+      </DialogTrigger>
+    );
+  }
+
+  return (
+    <Grid.Item colSpan={{ initial: '12', md: '3', lg: '2' }}>
+      <Flex direction="column" gap="4">
+        <Text weight="bold">{title}</Text>
+        {children}
+      </Flex>
+    </Grid.Item>
+  );
+};
+
+/** Props for the Content sub-component */
+interface ContentProps {
+  children: ReactNode;
+}
+
+/** Main content area that fills remaining grid space */
+const Content = ({ children }: ContentProps) => {
+  return (
+    <Grid.Item colSpan={{ initial: '12', md: '9', lg: '10' }}>
+      {children}
+    </Grid.Item>
+  );
+};
+
+/** Props for the FilterLayout root */
+interface FilterLayoutProps {
+  children: ReactNode;
+}
+
+/** A responsive layout with a filter sidebar that collapses into a dialog on smaller screens */
+export const FilterLayout = ({ children }: FilterLayoutProps) => {
+  return (
+    <Grid.Root columns="12" gap="6">
+      {children}
+    </Grid.Root>
+  );
+};
+
+FilterLayout.Filters = Filters;
+FilterLayout.Content = Content;

--- a/plugins/policy-reporter/src/components/FilterLayout/FilterLayout.tsx
+++ b/plugins/policy-reporter/src/components/FilterLayout/FilterLayout.tsx
@@ -8,8 +8,9 @@ import {
   Flex,
   Grid,
   Text,
-  useBreakpoint,
 } from '@backstage/ui';
+import useMediaQuery from '@material-ui/core/useMediaQuery';
+import { Theme } from '@material-ui/core/styles';
 import { RiFilter3Fill } from '@remixicon/react';
 
 /** Props for the Filters sub-component */
@@ -21,8 +22,11 @@ interface FiltersProps {
 
 /** Renders filter children as a sidebar on large screens, or inside a Dialog on smaller screens */
 const Filters = ({ children, title = 'Filters' }: FiltersProps) => {
-  const { down } = useBreakpoint();
-  const isSmallScreen = down('md');
+  // TODO: Migrate to BUI useBreakpoint once the performance warning is resolved
+  const isSmallScreen = useMediaQuery(
+    (theme: Theme) => theme.breakpoints.down('md'),
+    { noSsr: true },
+  );
   const [open, setOpen] = useState(false);
 
   if (isSmallScreen) {

--- a/plugins/policy-reporter/src/components/FilterLayout/index.ts
+++ b/plugins/policy-reporter/src/components/FilterLayout/index.ts
@@ -1,0 +1,1 @@
+export { FilterLayout } from './FilterLayout';

--- a/plugins/policy-reporter/src/components/PolicyReportsPage/PolicyReportsPage.tsx
+++ b/plugins/policy-reporter/src/components/PolicyReportsPage/PolicyReportsPage.tsx
@@ -1,5 +1,5 @@
 import { Content, EmptyState, Progress } from '@backstage/core-components';
-import { Box, Container, Flex, Header, ButtonLink } from '@backstage/ui';
+import { Container, Flex, Header, ButtonLink } from '@backstage/ui';
 import { useEnvironments } from '../../hooks/useEnvironments';
 import { SelectEnvironment } from '../SelectEnvironment';
 import { PolicyReportsTable } from '../PolicyReportsTable';

--- a/plugins/policy-reporter/src/components/PolicyReportsPage/PolicyReportsPage.tsx
+++ b/plugins/policy-reporter/src/components/PolicyReportsPage/PolicyReportsPage.tsx
@@ -1,5 +1,5 @@
 import { Content, EmptyState, Progress } from '@backstage/core-components';
-import { Box, Container, Flex, Grid, Header, ButtonLink } from '@backstage/ui';
+import { Box, Container, Flex, Header, ButtonLink } from '@backstage/ui';
 import { useEnvironments } from '../../hooks/useEnvironments';
 import { SelectEnvironment } from '../SelectEnvironment';
 import { PolicyReportsTable } from '../PolicyReportsTable';
@@ -9,6 +9,7 @@ import { SelectNamespace } from '../SelectNamespace';
 import { SearchField } from '../SearchField';
 import { PolicyReportsFiltersProvider } from '../../hooks/usePolicyReportsFilters';
 import { Filter } from '@kyverno/backstage-plugin-policy-reporter-common';
+import { FilterLayout } from '../FilterLayout';
 
 export interface PolicyReportsPageProps {
   title?: string;
@@ -71,20 +72,22 @@ export const PolicyReportsPage = ({
           customActions={<SelectEnvironment environments={environments} />}
         />
         <Content>
-          <Grid.Root columns="1" gap="4">
-            <Flex align="end" gap="4">
+          <FilterLayout>
+            <FilterLayout.Filters>
               <SelectStatus />
               <SelectSeverity />
               <SelectNamespace />
-              <Box width="300px" style={{ flexShrink: 0 }}>
+            </FilterLayout.Filters>
+            <FilterLayout.Content>
+              <Flex direction="column" gap="4">
                 <SearchField />
-              </Box>
-            </Flex>
-            <PolicyReportsTable
-              emptyContentText="No policies found"
-              policyDocumentationUrl={policyDocumentationUrl}
-            />
-          </Grid.Root>
+                <PolicyReportsTable
+                  emptyContentText="No policies found"
+                  policyDocumentationUrl={policyDocumentationUrl}
+                />
+              </Flex>
+            </FilterLayout.Content>
+          </FilterLayout>
         </Content>
       </Container>
     </PolicyReportsFiltersProvider>

--- a/plugins/policy-reporter/src/components/SelectNamespace/SelectNamespace.tsx
+++ b/plugins/policy-reporter/src/components/SelectNamespace/SelectNamespace.tsx
@@ -38,7 +38,6 @@ export const SelectNamespace = () => {
       value={filter.namespaces ?? []}
       onChange={handleChange}
       placeholder="All"
-      style={{ width: 200 }}
     />
   );
 };

--- a/plugins/policy-reporter/src/components/SelectSeverity/SelectSeverity.tsx
+++ b/plugins/policy-reporter/src/components/SelectSeverity/SelectSeverity.tsx
@@ -46,7 +46,6 @@ export const SelectSeverity = () => {
       value={filter.severities ?? []}
       onChange={handleChange}
       placeholder="All"
-      style={{ width: 200 }}
     />
   );
 };

--- a/plugins/policy-reporter/src/components/SelectStatus/SelectStatus.tsx
+++ b/plugins/policy-reporter/src/components/SelectStatus/SelectStatus.tsx
@@ -44,7 +44,6 @@ export const SelectStatus = () => {
       value={filter.status ?? []}
       onChange={handleChange}
       placeholder="All"
-      style={{ width: 200 }}
     />
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -6066,6 +6066,7 @@ __metadata:
     "@material-ui/core": "npm:^4.12.4"
     "@material-ui/icons": "npm:^4.11.3"
     "@material-ui/lab": "npm:4.0.0-alpha.61"
+    "@remixicon/react": "npm:^4.9.0"
     "@testing-library/jest-dom": "npm:^6.0.0"
     "@testing-library/react": "npm:^14.0.0"
     "@testing-library/user-event": "npm:^14.0.0"
@@ -8744,7 +8745,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@remixicon/react@npm:^4.6.0":
+"@remixicon/react@npm:^4.6.0, @remixicon/react@npm:^4.9.0":
   version: 4.9.0
   resolution: "@remixicon/react@npm:4.9.0"
   peerDependencies:


### PR DESCRIPTION
This PR adds a new FilterLayout component that will make possible to have filters on the left side of the page. This aligns with how Backstage already handle filters e.g catalog / notification pages. 

This is done to prepare for more filters I would like to add in the future e.g kind / sources / policy

## Screenshot

<img width="1670" height="910" alt="image" src="https://github.com/user-attachments/assets/74f62bfc-ea62-4e2b-a164-731cb24d8962" />

<img width="1185" height="910" alt="image" src="https://github.com/user-attachments/assets/1f7eebb5-d7ff-4ca9-8274-761554f22d9f" />
