### PR TITLE
fix(deps): limit @remixicon/react to < 4.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
   },
   "resolutions": {
     "@types/react": "^18",
-    "@types/react-dom": "^18"
+    "@types/react-dom": "^18",
+    "@remixicon/react": ">=4.6.0 <4.9.0"
   },
   "prettier": "@backstage/cli/config/prettier",
   "lint-staged": {

--- a/plugins/policy-reporter/package.json
+++ b/plugins/policy-reporter/package.json
@@ -66,7 +66,7 @@
     "@material-ui/core": "^4.12.4",
     "@material-ui/icons": "^4.11.3",
     "@material-ui/lab": "4.0.0-alpha.61",
-    "@remixicon/react": "^4.9.0",
+    "@remixicon/react": ">=4.6.0 <4.9.0",
     "qs": "^6.15.0",
     "react-use": "^17.6.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6066,7 +6066,7 @@ __metadata:
     "@material-ui/core": "npm:^4.12.4"
     "@material-ui/icons": "npm:^4.11.3"
     "@material-ui/lab": "npm:4.0.0-alpha.61"
-    "@remixicon/react": "npm:^4.9.0"
+    "@remixicon/react": "npm:>=4.6.0 <4.9.0"
     "@testing-library/jest-dom": "npm:^6.0.0"
     "@testing-library/react": "npm:^14.0.0"
     "@testing-library/user-event": "npm:^14.0.0"
@@ -8745,12 +8745,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@remixicon/react@npm:^4.6.0, @remixicon/react@npm:^4.9.0":
-  version: 4.9.0
-  resolution: "@remixicon/react@npm:4.9.0"
+"@remixicon/react@npm:>=4.6.0 <4.9.0":
+  version: 4.8.0
+  resolution: "@remixicon/react@npm:4.8.0"
   peerDependencies:
     react: ">=18.2.0"
-  checksum: 10c0/91bbadb677f45cf8b6687fdf9d273511fddb4e862f1da6c11bc7932acb578bcb26ae5b9e1eb62143a4e916b71797739a36d689866d5b0949f0f0f22c1684cb96
+  checksum: 10c0/edf4bb4f600e13ee24dac2cecb389b4bfe83764a5168b553b726b41d6b76bc8c24212f2e4f7d89abae395ba8479082646a122a2a066cd5c743e4e372e0a3c345
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR limits the remixicon/react package version to avoid issues with the new license added in 4.9.0