### PR TITLE
fix(namespace): add cleanup for invalid namespaces on env change

### DIFF
--- a/.changeset/major-wombats-crash.md
+++ b/.changeset/major-wombats-crash.md
@@ -1,0 +1,5 @@
+---
+'@kyverno/backstage-plugin-policy-reporter': patch
+---
+
+Fixed a bug where switching environments would retain the previously selected namespace, even if it didn't exist in the new environment.

--- a/plugins/policy-reporter/src/components/SelectNamespace/SelectNamespace.tsx
+++ b/plugins/policy-reporter/src/components/SelectNamespace/SelectNamespace.tsx
@@ -1,13 +1,31 @@
 import { Select } from '@backstage/ui';
-import { Key } from 'react';
+import { Key, useEffect, useRef } from 'react';
 import { usePolicyReportsFilters } from '../../hooks/usePolicyReportsFilters';
 import { useNamespaces } from '../../hooks/useNamespaces';
 
 export const SelectNamespace = () => {
   const { filter, updateFilter, environment } = usePolicyReportsFilters();
-  const { namespaces: availableNamespaces } = useNamespaces(environment);
+  const { namespaces } = useNamespaces(environment);
 
-  const options = availableNamespaces.map(ns => ({ value: ns, label: ns }));
+  const options = namespaces.map(ns => ({ value: ns, label: ns }));
+
+  const selectedNamespaces = filter.namespaces ?? [];
+
+  // Keep a ref so the effect can read the latest selection without making it
+  // a dependency — the effect should only trigger when available namespaces change.
+  const selectedNamespacesRef = useRef(selectedNamespaces);
+  selectedNamespacesRef.current = selectedNamespaces;
+
+  useEffect(() => {
+    const validNamespaces = new Set(namespaces);
+    const selected = selectedNamespacesRef.current;
+
+    if (selected.every(ns => validNamespaces.has(ns))) return;
+
+    updateFilter({
+      namespaces: selected.filter(ns => validNamespaces.has(ns)),
+    });
+  }, [namespaces, updateFilter]);
 
   const handleChange = (key: Key | Key[] | null) => {
     if (key === null) {
@@ -17,15 +35,13 @@ export const SelectNamespace = () => {
 
     if (!Array.isArray(key)) {
       updateFilter({
-        namespaces: availableNamespaces.includes(key as string)
-          ? [key as string]
-          : [],
+        namespaces: namespaces.includes(key as string) ? [key as string] : [],
       });
       return;
     }
 
     const filtered = key.filter((item): item is string =>
-      availableNamespaces.includes(item as string),
+      namespaces.includes(item as string),
     );
     updateFilter({ namespaces: filtered });
   };
@@ -35,7 +51,7 @@ export const SelectNamespace = () => {
       label="Namespace"
       selectionMode="multiple"
       options={options}
-      value={filter.namespaces ?? []}
+      value={selectedNamespaces}
       onChange={handleChange}
       placeholder="All"
     />

--- a/plugins/policy-reporter/src/hooks/usePolicyReportsFilters.tsx
+++ b/plugins/policy-reporter/src/hooks/usePolicyReportsFilters.tsx
@@ -6,6 +6,7 @@ import {
   useContext,
   useLayoutEffect,
   useMemo,
+  useRef,
 } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import type { Filter } from '@kyverno/backstage-plugin-policy-reporter-common';
@@ -67,13 +68,18 @@ export const PolicyReportsFiltersProvider = ({
     [urlEnvironment, defaultEnvironment],
   );
 
+  // setSearchParams is not stable (https://github.com/remix-run/react-router/issues/9991),
+  // so we hold it in a ref to keep updateParams/updateFilter stable across renders.
+  const setSearchParamsRef = useRef(setSearchParams);
+  setSearchParamsRef.current = setSearchParams;
+
   const updateParams = useCallback(
     (
       update:
         | Record<string, unknown>
         | ((prev: Record<string, unknown>) => Record<string, unknown>),
     ) => {
-      setSearchParams(
+      setSearchParamsRef.current(
         prev => {
           const prevParsed = qs.parse(prev.toString());
           const next =
@@ -86,7 +92,7 @@ export const PolicyReportsFiltersProvider = ({
         { replace: true },
       );
     },
-    [setSearchParams],
+    [],
   );
 
   useLayoutEffect(() => {
@@ -96,10 +102,7 @@ export const PolicyReportsFiltersProvider = ({
         environment: defaultEnvironment,
       });
     }
-    // setSearchParams isn't stable, hence disabling the exhaustive-deps check
-    // for more info please visit https://github.com/remix-run/react-router/issues/9991
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [defaultEnvironment, urlEnvironment, defaultFilters]);
+  }, [defaultEnvironment, urlEnvironment, defaultFilters, updateParams]);
 
   const updateFilter = useCallback(
     (update: Partial<Filter>) => {


### PR DESCRIPTION
This PR updates the SelectNamespace component to handle cleanup of invalid namespaces when switching to a new environment. 

This was causing issues when selecting namespace and switching to environment without that namespace available. 