### PR TITLE
feat(backend): configurable request headers for the Policy Reporter API

### DIFF
--- a/.changeset/policy-reporter-request-headers.md
+++ b/.changeset/policy-reporter-request-headers.md
@@ -1,0 +1,5 @@
+---
+'@kyverno/backstage-plugin-policy-reporter-backend': minor
+---
+
+Add `policyReporter.requestHeaders` config — a string→string map of HTTP headers injected into every outbound Policy Reporter API request, so the backend can authenticate through a gateway/proxy (auth headers, X-Scope-OrgID, etc.) without forking. Values support config substitution. No behaviour change when unset.

--- a/plugins/policy-reporter-backend/README.md
+++ b/plugins/policy-reporter-backend/README.md
@@ -25,3 +25,13 @@ const backend = createBackend();
 backend.start();
 
 ```
+
+## Authenticating to the Policy Reporter API (optional)
+
+If the Policy Reporter Core API sits behind a gateway/proxy that requires headers, set `policyReporter.requestHeaders` in app-config. Every outbound request to the Policy Reporter API gets these headers; values support config substitution so secrets stay in env/secret refs:
+
+```yaml
+policyReporter:
+  requestHeaders:
+    X-Partybus-Upstream-Secret: ${POLICY_REPORTER_UPSTREAM_SECRET}
+```

--- a/plugins/policy-reporter-backend/README.md
+++ b/plugins/policy-reporter-backend/README.md
@@ -33,5 +33,5 @@ If the Policy Reporter Core API sits behind a gateway/proxy that requires header
 ```yaml
 policyReporter:
   requestHeaders:
-    X-Partybus-Upstream-Secret: ${POLICY_REPORTER_UPSTREAM_SECRET}
+    Authorization: Bearer ${POLICY_REPORTER_API_TOKEN}
 ```

--- a/plugins/policy-reporter-backend/config.d.ts
+++ b/plugins/policy-reporter-backend/config.d.ts
@@ -1,0 +1,12 @@
+export interface Config {
+  policyReporter?: {
+    /**
+     * Optional HTTP headers added to every outbound request to the Policy
+     * Reporter REST API — e.g. to authenticate through a gateway/proxy. Header
+     * values support config substitution, so secrets can be supplied via
+     * environment/secret refs (e.g. ${POLICY_REPORTER_UPSTREAM_SECRET}).
+     * @visibility backend
+     */
+    requestHeaders?: { [headerName: string]: string };
+  };
+}

--- a/plugins/policy-reporter-backend/package.json
+++ b/plugins/policy-reporter-backend/package.json
@@ -18,6 +18,7 @@
       "@kyverno/backstage-plugin-policy-reporter-common"
     ]
   },
+  "configSchema": "config.d.ts",
   "publishConfig": {
     "access": "public",
     "main": "dist/index.cjs.js",

--- a/plugins/policy-reporter-backend/src/service/router.test.ts
+++ b/plugins/policy-reporter-backend/src/service/router.test.ts
@@ -44,6 +44,7 @@ describe('createRouter', () => {
   // assertions type-check cleanly under the repo-root tsconfig.
   let receivedSecret: string | null | undefined;
   let receivedNsSecret: string | null | undefined;
+  let receivedContentType: string | null | undefined;
 
   const server = setupServer(
     // Setup the mock response for Connector alter offset
@@ -51,6 +52,7 @@ describe('createRouter', () => {
       'http://kyverno.io/policy-reporter/api/v1/namespaced-resources/results',
       (req, res, ctx) => {
         receivedSecret = req.headers.get('X-Partybus-Upstream-Secret');
+        receivedContentType = req.headers.get('Content-Type');
         return res(
           ctx.status(200),
           ctx.json({
@@ -205,6 +207,38 @@ describe('createRouter', () => {
       expect(response.status).toBe(200);
       // the Headers API returns null for an absent header
       expect(receivedSecret).toBeNull();
+
+      receivedNsSecret = undefined;
+      const nsResponse = await request(app).get(
+        `/v1/namespaces?environment=resource%3Adefault%2Fprod`,
+      );
+      expect(nsResponse.status).toBe(200);
+      expect(receivedNsSecret).toBeNull();
+    });
+
+    it('does not let a configured header override Content-Type', async () => {
+      const router = await createRouter({
+        logger: mockServices.logger.mock(),
+        config: mockServices.rootConfig({
+          data: {
+            policyReporter: {
+              requestHeaders: { 'Content-Type': 'text/plain' },
+            },
+          },
+        }),
+        authService: mockServices.auth(),
+        catalogService: catalogServiceMock({
+          entities: mockEntities,
+        }) as CatalogService,
+      });
+      const appOverridingContentType = express().use(router);
+
+      receivedContentType = undefined;
+      const response = await request(appOverridingContentType).get(
+        `/namespaced-resources/results?environment=resource%3Adefault%2Fprod`,
+      );
+      expect(response.status).toBe(200);
+      expect(receivedContentType).toBe('application/json');
     });
   });
 });

--- a/plugins/policy-reporter-backend/src/service/router.test.ts
+++ b/plugins/policy-reporter-backend/src/service/router.test.ts
@@ -40,12 +40,14 @@ const mockEntities: Entity[] = [
 
 describe('createRouter', () => {
   let app: express.Express;
+  let receivedHeaders: Headers | undefined;
 
   const server = setupServer(
     // Setup the mock response for Connector alter offset
     rest.get(
       'http://kyverno.io/policy-reporter/api/v1/namespaced-resources/results',
-      (_req, res, ctx) => {
+      (req, res, ctx) => {
+        receivedHeaders = req.headers;
         return res(
           ctx.status(200),
           ctx.json({
@@ -149,6 +151,46 @@ describe('createRouter', () => {
 
       expect(response.status).toBe(200);
       expect(response.body).toStrictEqual(['default', 'kube-system']);
+    });
+  });
+
+  describe('requestHeaders config', () => {
+    let appWithHeaders: express.Express;
+
+    beforeAll(async () => {
+      const router = await createRouter({
+        logger: mockServices.logger.mock(),
+        config: mockServices.rootConfig({
+          data: {
+            policyReporter: {
+              requestHeaders: { 'X-Partybus-Upstream-Secret': 'topsecret' },
+            },
+          },
+        }),
+        authService: mockServices.auth(),
+        catalogService: catalogServiceMock({
+          entities: mockEntities,
+        }) as CatalogService,
+      });
+      appWithHeaders = express().use(router);
+    });
+
+    it('injects configured headers into the outbound Policy Reporter request', async () => {
+      receivedHeaders = undefined;
+      const response = await request(appWithHeaders).get(
+        `/namespaced-resources/results?environment=resource%3Adefault%2Fprod`,
+      );
+      expect(response.status).toBe(200);
+      expect(receivedHeaders?.get('x-partybus-upstream-secret')).toBe('topsecret');
+    });
+
+    it('still works (no injected header) when config is absent', async () => {
+      receivedHeaders = undefined;
+      const response = await request(app).get(
+        `/namespaced-resources/results?environment=resource%3Adefault%2Fprod`,
+      );
+      expect(response.status).toBe(200);
+      expect(receivedHeaders?.get('x-partybus-upstream-secret')).toBeNull();
     });
   });
 });

--- a/plugins/policy-reporter-backend/src/service/router.test.ts
+++ b/plugins/policy-reporter-backend/src/service/router.test.ts
@@ -41,6 +41,7 @@ const mockEntities: Entity[] = [
 describe('createRouter', () => {
   let app: express.Express;
   let receivedHeaders: Headers | undefined;
+  let receivedNsHeaders: Headers | undefined;
 
   const server = setupServer(
     // Setup the mock response for Connector alter offset
@@ -59,7 +60,8 @@ describe('createRouter', () => {
     ),
     rest.get(
       'http://kyverno.io/policy-reporter/api/v1/namespaces',
-      (_req, res, ctx) => {
+      (req, res, ctx) => {
+        receivedNsHeaders = req.headers;
         return res(ctx.status(200), ctx.json(['default', 'kube-system']));
       },
     ),
@@ -181,7 +183,20 @@ describe('createRouter', () => {
         `/namespaced-resources/results?environment=resource%3Adefault%2Fprod`,
       );
       expect(response.status).toBe(200);
+      // the Headers API normalises header names to lowercase
       expect(receivedHeaders?.get('x-partybus-upstream-secret')).toBe('topsecret');
+    });
+
+    it('injects configured headers into the outbound namespaces request', async () => {
+      receivedNsHeaders = undefined;
+      const response = await request(appWithHeaders).get(
+        `/v1/namespaces?environment=resource%3Adefault%2Fprod`,
+      );
+      expect(response.status).toBe(200);
+      // the Headers API normalises header names to lowercase
+      expect(receivedNsHeaders?.get('x-partybus-upstream-secret')).toBe(
+        'topsecret',
+      );
     });
 
     it('still works (no injected header) when config is absent', async () => {
@@ -190,6 +205,7 @@ describe('createRouter', () => {
         `/namespaced-resources/results?environment=resource%3Adefault%2Fprod`,
       );
       expect(response.status).toBe(200);
+      // the Headers API normalises header names to lowercase
       expect(receivedHeaders?.get('x-partybus-upstream-secret')).toBeNull();
     });
   });

--- a/plugins/policy-reporter-backend/src/service/router.test.ts
+++ b/plugins/policy-reporter-backend/src/service/router.test.ts
@@ -40,15 +40,17 @@ const mockEntities: Entity[] = [
 
 describe('createRouter', () => {
   let app: express.Express;
-  let receivedHeaders: Headers | undefined;
-  let receivedNsHeaders: Headers | undefined;
+  // Capture the extracted header VALUE (not the Headers object) so the
+  // assertions type-check cleanly under the repo-root tsconfig.
+  let receivedSecret: string | null | undefined;
+  let receivedNsSecret: string | null | undefined;
 
   const server = setupServer(
     // Setup the mock response for Connector alter offset
     rest.get(
       'http://kyverno.io/policy-reporter/api/v1/namespaced-resources/results',
       (req, res, ctx) => {
-        receivedHeaders = req.headers;
+        receivedSecret = req.headers.get('X-Partybus-Upstream-Secret');
         return res(
           ctx.status(200),
           ctx.json({
@@ -61,7 +63,7 @@ describe('createRouter', () => {
     rest.get(
       'http://kyverno.io/policy-reporter/api/v1/namespaces',
       (req, res, ctx) => {
-        receivedNsHeaders = req.headers;
+        receivedNsSecret = req.headers.get('X-Partybus-Upstream-Secret');
         return res(ctx.status(200), ctx.json(['default', 'kube-system']));
       },
     ),
@@ -178,35 +180,31 @@ describe('createRouter', () => {
     });
 
     it('injects configured headers into the outbound Policy Reporter request', async () => {
-      receivedHeaders = undefined;
+      receivedSecret = undefined;
       const response = await request(appWithHeaders).get(
         `/namespaced-resources/results?environment=resource%3Adefault%2Fprod`,
       );
       expect(response.status).toBe(200);
-      // the Headers API normalises header names to lowercase
-      expect(receivedHeaders?.get('x-partybus-upstream-secret')).toBe('topsecret');
+      expect(receivedSecret).toBe('topsecret');
     });
 
     it('injects configured headers into the outbound namespaces request', async () => {
-      receivedNsHeaders = undefined;
+      receivedNsSecret = undefined;
       const response = await request(appWithHeaders).get(
         `/v1/namespaces?environment=resource%3Adefault%2Fprod`,
       );
       expect(response.status).toBe(200);
-      // the Headers API normalises header names to lowercase
-      expect(receivedNsHeaders?.get('x-partybus-upstream-secret')).toBe(
-        'topsecret',
-      );
+      expect(receivedNsSecret).toBe('topsecret');
     });
 
     it('still works (no injected header) when config is absent', async () => {
-      receivedHeaders = undefined;
+      receivedSecret = undefined;
       const response = await request(app).get(
         `/namespaced-resources/results?environment=resource%3Adefault%2Fprod`,
       );
       expect(response.status).toBe(200);
-      // the Headers API normalises header names to lowercase
-      expect(receivedHeaders?.get('x-partybus-upstream-secret')).toBeNull();
+      // the Headers API returns null for an absent header
+      expect(receivedSecret).toBeNull();
     });
   });
 });

--- a/plugins/policy-reporter-backend/src/service/router.ts
+++ b/plugins/policy-reporter-backend/src/service/router.ts
@@ -81,8 +81,8 @@ export async function createRouter(
       `${ensureTrailingSlash(kyvernoEndpoint)}${uri}`,
       {
         headers: {
-          'Content-Type': 'application/json',
           ...extraHeaders,
+          'Content-Type': 'application/json',
         },
         method: 'GET',
       },
@@ -131,8 +131,8 @@ export async function createRouter(
       `${ensureTrailingSlash(kyvernoEndpoint)}${uri}`,
       {
         headers: {
-          'Content-Type': 'application/json',
           ...extraHeaders,
+          'Content-Type': 'application/json',
         },
         method: 'GET',
       },

--- a/plugins/policy-reporter-backend/src/service/router.ts
+++ b/plugins/policy-reporter-backend/src/service/router.ts
@@ -24,6 +24,8 @@ const ensureTrailingSlash = (url: string) =>
  * Lets the backend authenticate through a gateway/proxy without browser/direct
  * exposure. Values support Backstage config substitution, so secrets stay in
  * env/secret refs. Returns an empty object when unset (no behaviour change).
+ * Only string values are used; non-string values are ignored (the config
+ * schema types this as a string map).
  */
 function readRequestHeaders(config: RootConfigService): Record<string, string> {
   const raw = config.getOptional('policyReporter.requestHeaders');

--- a/plugins/policy-reporter-backend/src/service/router.ts
+++ b/plugins/policy-reporter-backend/src/service/router.ts
@@ -18,10 +18,32 @@ export interface RouterOptions {
 const ensureTrailingSlash = (url: string) =>
   url.endsWith('/') ? url : `${url}/`;
 
+/**
+ * Optional HTTP headers to add to every outbound Policy Reporter API request,
+ * read from `policyReporter.requestHeaders` (a string→string map) in app-config.
+ * Lets the backend authenticate through a gateway/proxy without browser/direct
+ * exposure. Values support Backstage config substitution, so secrets stay in
+ * env/secret refs. Returns an empty object when unset (no behaviour change).
+ */
+function readRequestHeaders(config: RootConfigService): Record<string, string> {
+  const raw = config.getOptional('policyReporter.requestHeaders');
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return {};
+  }
+  const headers: Record<string, string> = {};
+  for (const [name, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (typeof value === 'string') {
+      headers[name] = value;
+    }
+  }
+  return headers;
+}
+
 export async function createRouter(
   options: RouterOptions,
 ): Promise<express.Router> {
   const { logger, config, catalogService, authService } = options;
+  const extraHeaders = readRequestHeaders(config);
 
   const router = await createOpenApiRouter();
   router.use(express.json());
@@ -58,6 +80,7 @@ export async function createRouter(
       {
         headers: {
           'Content-Type': 'application/json',
+          ...extraHeaders,
         },
         method: 'GET',
       },
@@ -107,6 +130,7 @@ export async function createRouter(
       {
         headers: {
           'Content-Type': 'application/json',
+          ...extraHeaders,
         },
         method: 'GET',
       },


### PR DESCRIPTION
## What

Adds an optional `policyReporter.requestHeaders` config (a string→string map) to `@kyverno/backstage-plugin-policy-reporter-backend`. When set, those headers are added to every outbound request to the Policy Reporter REST API.

## Why

Today the backend's outbound `fetch` to the Policy Reporter Core API sends only `Content-Type`. Deployments that front the Core API with a gateway/proxy requiring headers (an auth token / `Authorization` bearer, `X-Scope-OrgID`, an upstream-shared-secret, etc.) can't use the plugin without patching/forking it. This makes that a config option.

```yaml
policyReporter:
  requestHeaders:
    Authorization: Bearer ${POLICY_REPORTER_API_TOKEN}
```

## Notes

- **No behaviour change when unset** — the map defaults to empty.
- `Content-Type: application/json` is applied last, so a configured header can't accidentally override it.
- Header values support Backstage config substitution, so secrets stay in env/secret refs.
- Read once at router creation (not per-request); ignores non-string values (the config schema types it as a string map).

## Included

- `config.d.ts` schema (+ `configSchema` in `package.json`) and a README section.
- Tests: header injection on both routes (`/namespaced-resources/results` + `/v1/namespaces`), back-compat (no header when unset), and Content-Type precedence — via msw request-header capture.
- Changeset (minor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
