### PR TITLE
fix(responsive): avoid cleanup on responsive changes

### DIFF
--- a/.changeset/cool-pugs-poke.md
+++ b/.changeset/cool-pugs-poke.md
@@ -2,4 +2,4 @@
 '@kyverno/backstage-plugin-policy-reporter': patch
 ---
 
-Fixed namespace, kind, and category filters being cleared when the responsive filter layout remounts. Cleanup now skips while option lists are loading or temporarily empty.
+Fixed namespace, kind, sources and category filters being cleared when the responsive filter layout remounts. Cleanup now skips while option lists are loading or temporarily empty.

--- a/.changeset/cool-pugs-poke.md
+++ b/.changeset/cool-pugs-poke.md
@@ -1,0 +1,5 @@
+---
+'@kyverno/backstage-plugin-policy-reporter': patch
+---
+
+Fixed namespace, kind, and category filters being cleared when the responsive filter layout remounts. Cleanup now skips while option lists are loading or temporarily empty.

--- a/plugins/policy-reporter/src/components/SelectCategory/SelectCategory.tsx
+++ b/plugins/policy-reporter/src/components/SelectCategory/SelectCategory.tsx
@@ -21,10 +21,13 @@ export const SelectCategory = () => {
     },
   });
 
-  const categories = useMemo(
-    () => new Set(categoryOptions.items.map(c => c.label)),
-    [categoryOptions.items],
-  );
+  const categories = useMemo(() => {
+    if (categoryOptions.isLoading || categoryOptions.items.length === 0) {
+      return undefined;
+    }
+
+    return new Set(categoryOptions.items.map(c => c.label));
+  }, [categoryOptions.isLoading, categoryOptions.items]);
 
   // useRef to avoid dependency on the useAsyncList result
   const categoryRef = useRef(categoryOptions);
@@ -43,6 +46,8 @@ export const SelectCategory = () => {
   selectedCategoriesRef.current = selectedCategories;
 
   useEffect(() => {
+    if (!categories) return;
+
     const selected = selectedCategoriesRef.current;
 
     if (selected.every(category => categories.has(category))) return;
@@ -57,6 +62,8 @@ export const SelectCategory = () => {
       updateFilter({ categories: [] });
       return;
     }
+
+    if (!categories) return;
 
     if (!Array.isArray(key)) {
       updateFilter({

--- a/plugins/policy-reporter/src/components/SelectKind/SelectKind.tsx
+++ b/plugins/policy-reporter/src/components/SelectKind/SelectKind.tsx
@@ -21,10 +21,13 @@ export const SelectKind = () => {
     },
   });
 
-  const kinds = useMemo(
-    () => new Set(kindOptions.items.map(k => k.label)),
-    [kindOptions.items],
-  );
+  const kinds = useMemo(() => {
+    if (kindOptions.isLoading || kindOptions.items.length === 0) {
+      return undefined;
+    }
+
+    return new Set(kindOptions.items.map(k => k.label));
+  }, [kindOptions.isLoading, kindOptions.items]);
 
   const kindRef = useRef(kindOptions);
   kindRef.current = kindOptions;
@@ -39,6 +42,8 @@ export const SelectKind = () => {
   selectedKindsRef.current = selectedKinds;
 
   useEffect(() => {
+    if (!kinds) return;
+
     const selected = selectedKindsRef.current;
 
     if (selected.every(kind => kinds.has(kind))) return;
@@ -53,6 +58,8 @@ export const SelectKind = () => {
       updateFilter({ kinds: [] });
       return;
     }
+
+    if (!kinds) return;
 
     if (!Array.isArray(key)) {
       updateFilter({

--- a/plugins/policy-reporter/src/components/SelectNamespace/SelectNamespace.tsx
+++ b/plugins/policy-reporter/src/components/SelectNamespace/SelectNamespace.tsx
@@ -21,10 +21,13 @@ export const SelectNamespace = () => {
     },
   });
 
-  const namespaces = useMemo(
-    () => new Set(namespaceOptions.items.map(ns => ns.label)),
-    [namespaceOptions.items],
-  );
+  const namespaces = useMemo(() => {
+    if (namespaceOptions.isLoading || namespaceOptions.items.length === 0) {
+      return undefined;
+    }
+
+    return new Set(namespaceOptions.items.map(ns => ns.label));
+  }, [namespaceOptions.isLoading, namespaceOptions.items]);
 
   // useRef to avoid dependency on the useAsyncList result
   const namespacesRef = useRef(namespaceOptions);
@@ -43,6 +46,8 @@ export const SelectNamespace = () => {
   selectedNamespacesRef.current = selectedNamespaces;
 
   useEffect(() => {
+    if (!namespaces) return;
+
     const selected = selectedNamespacesRef.current;
 
     if (selected.every(ns => namespaces.has(ns))) return;
@@ -57,6 +62,8 @@ export const SelectNamespace = () => {
       updateFilter({ namespaces: [] });
       return;
     }
+
+    if (!namespaces) return;
 
     if (!Array.isArray(key)) {
       updateFilter({

--- a/plugins/policy-reporter/src/components/SelectSource/SelectSource.tsx
+++ b/plugins/policy-reporter/src/components/SelectSource/SelectSource.tsx
@@ -21,10 +21,12 @@ export const SelectSource = () => {
     },
   });
 
-  const sources = useMemo(
-    () => new Set(sourceOptions.items.map(s => s.label)),
-    [sourceOptions.items],
-  );
+  const sources = useMemo(() => {
+    if (sourceOptions.isLoading || sourceOptions.items.length === 0) {
+      return undefined;
+    }
+    return new Set(sourceOptions.items.map(s => s.label));
+  }, [sourceOptions.items, sourceOptions.isLoading]);
 
   // useRef to avoid dependency on the useAsyncList result
   const sourceRef = useRef(sourceOptions);
@@ -43,6 +45,7 @@ export const SelectSource = () => {
   selectedSourcesRef.current = selectedSources;
 
   useEffect(() => {
+    if (!sources) return;
     const selected = selectedSourcesRef.current;
 
     if (selected.every(source => sources.has(source))) return;
@@ -53,6 +56,8 @@ export const SelectSource = () => {
   }, [sources, updateFilter]);
 
   const handleChange = (key: Key | Key[] | null) => {
+    if (!sources) return;
+
     if (key === null) {
       updateFilter({ sources: [] });
       return;


### PR DESCRIPTION
This PR fix issues that was introduced by #118 causing the FilterLayout to trigger reset of filters. It will not check the current isLoading state and verify it's not an empty array before doing any reset of filters.