### PR TITLE
feat(policies): add new filter option to PolicyReportsPage

### DIFF
--- a/.changeset/cool-pugs-poke.md
+++ b/.changeset/cool-pugs-poke.md
@@ -2,4 +2,4 @@
 '@kyverno/backstage-plugin-policy-reporter': patch
 ---
 
-Fixed namespace, kind, and category filters being cleared when the responsive filter layout remounts. Cleanup now skips while option lists are loading or temporarily empty.
+Fixed namespace, kind, sources and category filters being cleared when the responsive filter layout remounts. Cleanup now skips while option lists are loading or temporarily empty.

--- a/.changeset/cool-pugs-poke.md
+++ b/.changeset/cool-pugs-poke.md
@@ -2,4 +2,4 @@
 '@kyverno/backstage-plugin-policy-reporter': patch
 ---
 
-Fixed namespace, kind, sources and category filters being cleared when the responsive filter layout remounts. Cleanup now skips while option lists are loading or temporarily empty.
+Fixed namespace, kind, and category filters being cleared when the responsive filter layout remounts. Cleanup now skips while option lists are loading or temporarily empty.

--- a/.changeset/deep-jars-trains.md
+++ b/.changeset/deep-jars-trains.md
@@ -1,0 +1,7 @@
+---
+'@kyverno/backstage-plugin-policy-reporter-backend': minor
+'@kyverno/backstage-plugin-policy-reporter-common': minor
+'@kyverno/backstage-plugin-policy-reporter': minor
+---
+
+Added policy filtering to the PolicyReportsPage. Users can now filter the list of policy reports by selecting one or more policies from the selected cluster.

--- a/plugins/policy-reporter-backend/src/schema/openapi.yaml
+++ b/plugins/policy-reporter-backend/src/schema/openapi.yaml
@@ -347,6 +347,68 @@ paths:
               schema:
                 $ref: '#/components/schemas/RequestError'
 
+  /v1/namespaced-resources/policies:
+    get:
+      summary: Get policies with namespaced policy results
+      description: List of all Policies with namespace scoped results
+      operationId: getPolicies
+      parameters:
+        - name: environment
+          in: query
+          required: true
+          description: The environment entity reference (URL encoded)
+          schema:
+            type: string
+            example: 'default/component/my-service'
+        - name: sources
+          in: query
+          description: Filter by a list of sources
+          schema:
+            type: array
+            items:
+              type: string
+          style: form
+          explode: true
+        - name: namespaces
+          in: query
+          description: Filter by a list of namespaces
+          schema:
+            type: array
+            items:
+              type: string
+          style: form
+          explode: true
+        - name: categories
+          in: query
+          description: Filter by a list of categories
+          schema:
+            type: array
+            items:
+              type: string
+          style: form
+          explode: true
+      responses:
+        '200':
+          description: List of policies
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+        '400':
+          description: Bad request - invalid entityRef or missing annotation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RequestError'
+        '500':
+          description: Internal server error - failed to fetch policies
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RequestError'
+
 components:
   schemas:
     Status:
@@ -522,7 +584,6 @@ components:
           additionalProperties:
             type: string
           description: Additional key-value properties
-
     RequestError:
       type: object
       required:

--- a/plugins/policy-reporter-backend/src/schema/openapi/generated/apis/Api.server.ts
+++ b/plugins/policy-reporter-backend/src/schema/openapi/generated/apis/Api.server.ts
@@ -69,6 +69,18 @@ export type GetNamespaces = {
 /**
  * @public
  */
+export type GetPolicies = {
+  query: {
+    environment: string;
+    sources?: Array<string>;
+    namespaces?: Array<string>;
+    categories?: Array<string>;
+  };
+  response: Array<string> | RequestError | RequestError;
+};
+/**
+ * @public
+ */
 export type GetSources = {
   query: {
     environment: string;
@@ -84,6 +96,8 @@ export type EndpointMap = {
   '#get|/namespaced-resources/results': GetNamespacedResults;
 
   '#get|/v1/namespaces': GetNamespaces;
+
+  '#get|/v1/namespaced-resources/policies': GetPolicies;
 
   '#get|/v1/namespaced-resources/sources': GetSources;
 };

--- a/plugins/policy-reporter-backend/src/schema/openapi/generated/router.ts
+++ b/plugins/policy-reporter-backend/src/schema/openapi/generated/router.ts
@@ -533,6 +533,100 @@ export const spec = {
         },
       },
     },
+    '/v1/namespaced-resources/policies': {
+      get: {
+        summary: 'Get policies with namespaced policy results',
+        description: 'List of all Policies with namespace scoped results',
+        operationId: 'getPolicies',
+        parameters: [
+          {
+            name: 'environment',
+            in: 'query',
+            required: true,
+            description: 'The environment entity reference (URL encoded)',
+            schema: {
+              type: 'string',
+              example: 'default/component/my-service',
+            },
+          },
+          {
+            name: 'sources',
+            in: 'query',
+            description: 'Filter by a list of sources',
+            schema: {
+              type: 'array',
+              items: {
+                type: 'string',
+              },
+            },
+            style: 'form',
+            explode: true,
+          },
+          {
+            name: 'namespaces',
+            in: 'query',
+            description: 'Filter by a list of namespaces',
+            schema: {
+              type: 'array',
+              items: {
+                type: 'string',
+              },
+            },
+            style: 'form',
+            explode: true,
+          },
+          {
+            name: 'categories',
+            in: 'query',
+            description: 'Filter by a list of categories',
+            schema: {
+              type: 'array',
+              items: {
+                type: 'string',
+              },
+            },
+            style: 'form',
+            explode: true,
+          },
+        ],
+        responses: {
+          '200': {
+            description: 'List of policies',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'array',
+                  items: {
+                    type: 'string',
+                  },
+                },
+              },
+            },
+          },
+          '400': {
+            description:
+              'Bad request - invalid entityRef or missing annotation',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/RequestError',
+                },
+              },
+            },
+          },
+          '500': {
+            description: 'Internal server error - failed to fetch policies',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/RequestError',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
   },
   components: {
     schemas: {

--- a/plugins/policy-reporter-backend/src/service/router.test.ts
+++ b/plugins/policy-reporter-backend/src/service/router.test.ts
@@ -86,6 +86,16 @@ describe('createRouter', () => {
         );
       },
     ),
+
+    rest.get(
+      'http://kyverno.io/policy-reporter/api/v1/namespaced-resources/policies',
+      (_req, res, ctx) => {
+        return res(
+          ctx.status(200),
+          ctx.json(['require-non-root-groups', 'require-request-limits']),
+        );
+      },
+    ),
   );
 
   beforeAll(async () => {
@@ -276,6 +286,43 @@ describe('createRouter', () => {
       expect(response.body).toStrictEqual([
         'Pod Security Standards (Default)',
         'Pod Security Standards (Restricted)',
+      ]);
+    });
+  });
+
+  describe('policies', () => {
+    it('Should return 400 if entity is missing kyverno.io/endpoint annotation', async () => {
+      const response = await request(app).get(
+        `/v1/namespaced-resources/policies?environment=resource%3Adefault%2Fdev`,
+      );
+
+      expect(response.status).toBe(400);
+      expect(response.body).toStrictEqual({
+        error: `Entity missing 'kyverno.io/endpoint' annotation`,
+      });
+    });
+
+    it('Should return 400 if entity is invalid', async () => {
+      const response = await request(app).get(
+        `/v1/namespaced-resources/policies?environment=resource%3Adefault%2Finvalid`,
+      );
+
+      expect(response.status).toBe(400);
+      expect(response.body).toStrictEqual({
+        error: `Invalid entityRef`,
+      });
+    });
+
+    it('Should return 200 and valid response when entity is valid', async () => {
+      const response = await request(app).get(
+        `/v1/namespaced-resources/policies?environment=resource%3Adefault%2Fprod`,
+      );
+
+      expect(response.status).toBe(200);
+
+      expect(response.body).toStrictEqual([
+        'require-non-root-groups',
+        'require-request-limits',
       ]);
     });
   });

--- a/plugins/policy-reporter-backend/src/service/router.ts
+++ b/plugins/policy-reporter-backend/src/service/router.ts
@@ -261,6 +261,53 @@ export async function createRouter(
     },
   );
 
+  router.get('/v1/namespaced-resources/policies', async (request, response) => {
+    // Get entityRef from query.
+    const entityRef = decodeURIComponent(request.query.environment);
+
+    const credentials = await authService.getOwnServiceCredentials();
+    const entity = await catalogService.getEntityByRef(entityRef, {
+      credentials,
+    });
+
+    if (!entity) {
+      return response.status(400).json({ error: 'Invalid entityRef' });
+    }
+
+    const kyvernoEndpoint =
+      entity?.metadata.annotations?.[KYVERNO_ENDPOINT_ANNOTATION];
+
+    if (!kyvernoEndpoint) {
+      return response
+        .status(400)
+        .json({ error: `Entity missing 'kyverno.io/endpoint' annotation` });
+    }
+
+    const uriTemplate = `v1/namespaced-resources/policies{?sources*,namespaces*,categories*}`;
+    const uri = parser.parse(uriTemplate).expand({
+      ...request.query,
+    });
+
+    const policyResponse = await fetch(
+      `${ensureTrailingSlash(kyvernoEndpoint)}${uri}`,
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        method: 'GET',
+      },
+    );
+
+    if (!policyResponse.ok) {
+      return response.status(500).json({
+        error: `Failed to fetch policies: ${policyResponse.statusText}`,
+      });
+    }
+
+    const result = await policyResponse.json();
+    return response.status(200).json(result);
+  });
+
   const middleware = MiddlewareFactory.create({ logger, config });
 
   router.use(middleware.error());

--- a/plugins/policy-reporter-common/src/schema/openapi/generated/apis/Api.client.ts
+++ b/plugins/policy-reporter-common/src/schema/openapi/generated/apis/Api.client.ts
@@ -86,6 +86,17 @@ export type GetNamespaces = {
 /**
  * @public
  */
+export type GetPolicies = {
+  query: {
+    environment: string;
+    sources?: Array<string>;
+    namespaces?: Array<string>;
+    categories?: Array<string>;
+  };
+};
+/**
+ * @public
+ */
 export type GetSources = {
   query: {
     environment: string;
@@ -221,6 +232,36 @@ export class DefaultApiClient {
     const baseUrl = await this.discoveryApi.getBaseUrl(pluginId);
 
     const uriTemplate = `/v1/namespaces{?environment,sources*,categories*,policies*}`;
+
+    const uri = parser.parse(uriTemplate).expand({
+      ...request.query,
+    });
+
+    return await this.fetchApi.fetch(`${baseUrl}${uri}`, {
+      headers: {
+        'Content-Type': 'application/json',
+        ...(options?.token && { Authorization: `Bearer ${options?.token}` }),
+      },
+      method: 'GET',
+    });
+  }
+
+  /**
+   * List of all Policies with namespace scoped results
+   * Get policies with namespaced policy results
+   * @param environment - The environment entity reference (URL encoded)
+   * @param sources - Filter by a list of sources
+   * @param namespaces - Filter by a list of namespaces
+   * @param categories - Filter by a list of categories
+   */
+  public async getPolicies(
+    // @ts-ignore
+    request: GetPolicies,
+    options?: RequestOptions,
+  ): Promise<TypedResponse<Array<string>>> {
+    const baseUrl = await this.discoveryApi.getBaseUrl(pluginId);
+
+    const uriTemplate = `/v1/namespaced-resources/policies{?environment,sources*,namespaces*,categories*}`;
 
     const uri = parser.parse(uriTemplate).expand({
       ...request.query,

--- a/plugins/policy-reporter/src/components/PolicyReportsPage/PolicyReportsPage.tsx
+++ b/plugins/policy-reporter/src/components/PolicyReportsPage/PolicyReportsPage.tsx
@@ -13,6 +13,7 @@ import { FilterLayout } from '../FilterLayout';
 import { SelectSource } from '../SelectSource';
 import { SelectKind } from '../SelectKind';
 import { SelectCategory } from '../SelectCategory';
+import { SelectPolicy } from '../SelectPolicy';
 
 export interface PolicyReportsPageProps {
   title?: string;
@@ -85,6 +86,7 @@ export const PolicyReportsPage = ({
               <SelectSource />
               <SelectKind />
               <SelectCategory />
+              <SelectPolicy />
             </FilterLayout.Filters>
             <FilterLayout.Content>
               <Flex direction="column" gap="4">

--- a/plugins/policy-reporter/src/components/SelectPolicy/SelectPolicy.test.tsx
+++ b/plugins/policy-reporter/src/components/SelectPolicy/SelectPolicy.test.tsx
@@ -10,7 +10,7 @@ const mockGetPolicies = jest.fn().mockResolvedValue({
 });
 
 const mockPolicyReportApiRef = {
-  mockGetPolicies: mockGetPolicies,
+  getPolicies: mockGetPolicies,
 };
 
 const renderWithEnv = (defaultFilters: Record<string, unknown> = {}) =>

--- a/plugins/policy-reporter/src/components/SelectPolicy/SelectPolicy.test.tsx
+++ b/plugins/policy-reporter/src/components/SelectPolicy/SelectPolicy.test.tsx
@@ -1,0 +1,57 @@
+import { TestApiProvider, renderInTestApp } from '@backstage/test-utils';
+import { SelectPolicy } from './SelectPolicy';
+import { policyReporterApiRef } from '../../api';
+import { PolicyReportsFiltersProvider } from '../../hooks/usePolicyReportsFilters';
+
+const mockGetPolicies = jest.fn().mockResolvedValue({
+  json: jest
+    .fn()
+    .mockResolvedValue(['require-non-root-groups', 'require-request-limits']),
+});
+
+const mockPolicyReportApiRef = {
+  mockGetPolicies: mockGetPolicies,
+};
+
+const renderWithEnv = (defaultFilters: Record<string, unknown> = {}) =>
+  renderInTestApp(
+    <TestApiProvider
+      apis={[[policyReporterApiRef, mockPolicyReportApiRef as any]]}
+    >
+      <PolicyReportsFiltersProvider
+        defaultEnvironment="resource:default/dev"
+        defaultFilters={defaultFilters}
+      >
+        <SelectPolicy />
+      </PolicyReportsFiltersProvider>
+    </TestApiProvider>,
+  );
+
+describe('SelectPolicy', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render the selected policy from provider defaults', async () => {
+    const extension = await renderWithEnv({
+      policies: ['require-non-root-groups'],
+    });
+    expect(extension.getAllByText('require-non-root-groups')).toBeTruthy();
+    expect(extension.getByText('Policy')).toBeTruthy();
+  });
+
+  it('should render multiple selected policies from provider defaults', async () => {
+    const extension = await renderWithEnv({
+      policies: ['require-non-root-groups', 'require-request-limits'],
+    });
+    expect(extension.getAllByText('require-non-root-groups')).toBeTruthy();
+    expect(extension.getAllByText('require-request-limits')).toBeTruthy();
+    expect(extension.getByText('Policy')).toBeTruthy();
+  });
+
+  it('should render all when no defaults are set', async () => {
+    const extension = await renderWithEnv();
+    expect(extension.getByText('All')).toBeTruthy();
+    expect(extension.getByText('Policy')).toBeTruthy();
+  });
+});

--- a/plugins/policy-reporter/src/components/SelectPolicy/SelectPolicy.tsx
+++ b/plugins/policy-reporter/src/components/SelectPolicy/SelectPolicy.tsx
@@ -1,0 +1,90 @@
+import { IdentifiedOption, Select, useAsyncList } from '@backstage/ui';
+import { Key, useEffect, useMemo, useRef } from 'react';
+import { usePolicyReportsFilters } from '../../hooks/usePolicyReportsFilters';
+import { policyReporterApiRef } from '../../api';
+import { useApi } from '@backstage/frontend-plugin-api';
+
+export const SelectPolicy = () => {
+  const { filter, updateFilter, environment } = usePolicyReportsFilters();
+  const api = useApi(policyReporterApiRef);
+
+  const policyOptions = useAsyncList<IdentifiedOption>({
+    async load({}) {
+      if (!environment) return { items: [] };
+      const response = await api.getPolicies({ query: { environment } });
+
+      const result = await response.json();
+
+      return {
+        items: result.map(s => ({ id: s, label: s })),
+      };
+    },
+  });
+
+  const policies = useMemo(() => {
+    if (policyOptions.isLoading || policyOptions.items.length === 0) {
+      return undefined;
+    }
+
+    return new Set(policyOptions.items.map(s => s.label));
+  }, [policyOptions.items, policyOptions.isLoading]);
+
+  // useRef to avoid dependency on the useAsyncList result
+  const policyRef = useRef(policyOptions);
+  policyRef.current = policyOptions;
+
+  // Fetch policies again after changes to the environment
+  useEffect(() => {
+    policyRef.current.reload();
+  }, [environment]);
+
+  const selectedPolicies = filter.policies ?? [];
+
+  // Keep a ref so the effect can read the latest selection without making it
+  // a dependency — the effect should only trigger when available policies change.
+  const selectedPoliciesRef = useRef(selectedPolicies);
+  selectedPoliciesRef.current = selectedPolicies;
+
+  useEffect(() => {
+    if (!policies) return;
+    const selected = selectedPoliciesRef.current;
+
+    if (selected.every(policy => policies.has(policy))) return;
+
+    updateFilter({
+      policies: selected.filter(policy => policies.has(policy)),
+    });
+  }, [policies, updateFilter]);
+
+  const handleChange = (key: Key | Key[] | null) => {
+    if (!policies) return;
+
+    if (key === null) {
+      updateFilter({ policies: [] });
+      return;
+    }
+
+    if (!Array.isArray(key)) {
+      updateFilter({
+        policies: policies.has(key as string) ? [key as string] : [],
+      });
+      return;
+    }
+
+    const filtered = key.filter((item): item is string =>
+      policies.has(item as string),
+    );
+    updateFilter({ policies: filtered });
+  };
+
+  return (
+    <Select
+      label="Policy"
+      selectionMode="multiple"
+      options={policyOptions}
+      value={selectedPolicies}
+      onChange={handleChange}
+      placeholder="All"
+    />
+  );
+};

--- a/plugins/policy-reporter/src/components/SelectPolicy/index.ts
+++ b/plugins/policy-reporter/src/components/SelectPolicy/index.ts
@@ -1,0 +1,1 @@
+export { SelectPolicy } from './SelectPolicy';


### PR DESCRIPTION
This PR adds policy filtering to the PolicyReportsPage. Users can now filter the list of policy reports by selecting one or more policies from the selected cluster.