### PR TITLE
feat(backend): add service for policy reporter and custom headers support

### DIFF
--- a/.changeset/cool-pugs-poke.md
+++ b/.changeset/cool-pugs-poke.md
@@ -2,4 +2,4 @@
 '@kyverno/backstage-plugin-policy-reporter': patch
 ---
 
-Fixed namespace, kind, and category filters being cleared when the responsive filter layout remounts. Cleanup now skips while option lists are loading or temporarily empty.
+Fixed namespace, kind, sources and category filters being cleared when the responsive filter layout remounts. Cleanup now skips while option lists are loading or temporarily empty.

--- a/.changeset/cool-pugs-poke.md
+++ b/.changeset/cool-pugs-poke.md
@@ -2,4 +2,4 @@
 '@kyverno/backstage-plugin-policy-reporter': patch
 ---
 
-Fixed namespace, kind, sources and category filters being cleared when the responsive filter layout remounts. Cleanup now skips while option lists are loading or temporarily empty.
+Fixed namespace, kind, and category filters being cleared when the responsive filter layout remounts. Cleanup now skips while option lists are loading or temporarily empty.

--- a/.changeset/curly-ants-tickle.md
+++ b/.changeset/curly-ants-tickle.md
@@ -1,0 +1,5 @@
+---
+'@kyverno/backstage-plugin-policy-reporter-backend': minor
+---
+
+Added additional responses to all routes, they can now also return 404, 502 and 503

--- a/.changeset/rare-rabbits-pay.md
+++ b/.changeset/rare-rabbits-pay.md
@@ -3,3 +3,9 @@
 ---
 
 Add support for configuring requestHeaders for the Policy Reporter Backend in your config using policyReporter.requestHeaders. This can be used for configuring Basic Auth credentials to the backend.
+
+```yaml
+policyReporter:
+  requestHeaders:
+    Authorization: Bearer ${POLICY_REPORTER_API_TOKEN}
+```

--- a/.changeset/rare-rabbits-pay.md
+++ b/.changeset/rare-rabbits-pay.md
@@ -1,0 +1,5 @@
+---
+'@kyverno/backstage-plugin-policy-reporter-backend': minor
+---
+
+Add support for configuring requestHeaders for the Policy Reporter Backend in your config using policyReporter.requestHeaders. This can be used for configuring Basic Auth credentials to the backend.

--- a/README.md
+++ b/README.md
@@ -184,3 +184,16 @@ metadata:
 +    kyverno.io/kind: Deployment,Pod                 # Specify the kind(s) of the Kubernetes resource(s)
 +    kyverno.io/resource-name: policy-reporter       # Specify the name of the resource
 ```
+
+## Authenticating to the Policy Reporter API (optional)
+
+If the Policy Reporter Core APIs sit behind a gateway/proxy that requires headers, set `policyReporter.requestHeaders` in app-config. Every outbound request to all the Policy Reporter APIs gets these headers:
+
+```yaml
+policyReporter:
+  requestHeaders:
+    Authorization: Bearer ${POLICY_REPORTER_API_TOKEN}
+```
+
+> [!NOTE]
+> If you have multiple cluster with Policy Reporter API running using different credentials, configuring headers per cluster or environment is currently not supported

--- a/plugins/policy-reporter-backend/config.d.ts
+++ b/plugins/policy-reporter-backend/config.d.ts
@@ -1,0 +1,10 @@
+export interface Config {
+  policyReporter?: {
+    /**
+     * Optional HTTP headers forwarded with every outbound request to every Policy Reporter API
+     * Typically used to authenticate through a gateway/proxy.
+     * @visibility backend
+     */
+    requestHeaders?: { [key: string]: string };
+  };
+}

--- a/plugins/policy-reporter-backend/package.json
+++ b/plugins/policy-reporter-backend/package.json
@@ -47,6 +47,7 @@
     "@backstage/errors": "backstage:^",
     "@backstage/plugin-catalog-node": "backstage:^",
     "@backstage/repo-tools": "backstage:^",
+    "@backstage/types": "backstage:^",
     "@kyverno/backstage-plugin-policy-reporter-common": "workspace:^",
     "@types/express": "*",
     "express": "^4.17.1",

--- a/plugins/policy-reporter-backend/package.json
+++ b/plugins/policy-reporter-backend/package.json
@@ -44,6 +44,7 @@
     "@backstage/backend-openapi-utils": "backstage:^",
     "@backstage/backend-plugin-api": "backstage:^",
     "@backstage/config": "backstage:^",
+    "@backstage/errors": "backstage:^",
     "@backstage/plugin-catalog-node": "backstage:^",
     "@backstage/repo-tools": "backstage:^",
     "@kyverno/backstage-plugin-policy-reporter-common": "workspace:^",

--- a/plugins/policy-reporter-backend/package.json
+++ b/plugins/policy-reporter-backend/package.json
@@ -68,7 +68,9 @@
     "msw": "^1.0.0",
     "supertest": "^6.2.4"
   },
+  "configSchema": "config.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "config.d.ts"
   ]
 }

--- a/plugins/policy-reporter-backend/src/plugin.ts
+++ b/plugins/policy-reporter-backend/src/plugin.ts
@@ -4,6 +4,7 @@ import {
 } from '@backstage/backend-plugin-api';
 import { createRouter } from './service/router';
 import { catalogServiceRef } from '@backstage/plugin-catalog-node';
+import { PolicyReporterService } from './service/policyReporterService';
 
 /**
  * kyvernoPolicyReportsPlugin backend plugin
@@ -22,12 +23,18 @@ export const kyvernoPolicyReportsPlugin = createBackendPlugin({
         authService: coreServices.auth,
       },
       async init({ httpRouter, logger, config, catalogService, authService }) {
+        const policyReporterService = new PolicyReporterService({
+          logger,
+          configService: config,
+          catalogService,
+          authService,
+        });
+
         httpRouter.use(
           await createRouter({
             logger,
             config,
-            catalogService,
-            authService,
+            policyReporterService,
           }),
         );
       },

--- a/plugins/policy-reporter-backend/src/schema/openapi.yaml
+++ b/plugins/policy-reporter-backend/src/schema/openapi.yaml
@@ -132,13 +132,31 @@ paths:
               schema:
                 $ref: '#/components/schemas/ResultList'
         '400':
-          description: Bad request - invalid entityRef or missing annotation
+          description: Bad request - environment entity missing required annotations
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RequestError'
+        '404':
+          description: Not Found - environment entity not found in the catalog
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/RequestError'
         '500':
           description: Internal server error - failed to fetch policies
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RequestError'
+        '502':
+          description: Bad Gateway
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RequestError'
+        '503':
+          description: Service Unavailable
           content:
             application/json:
               schema:
@@ -167,13 +185,31 @@ paths:
                 items:
                   type: string
         '400':
-          description: Bad request - invalid entityRef or missing annotation
+          description: Bad request - environment entity missing required annotations
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RequestError'
+        '404':
+          description: Not Found - environment entity not found in the catalog
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/RequestError'
         '500':
           description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RequestError'
+        '502':
+          description: Bad Gateway
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RequestError'
+        '503':
+          description: Service Unavailable
           content:
             application/json:
               schema:
@@ -220,13 +256,31 @@ paths:
                 items:
                   type: string
         '400':
-          description: Bad request - invalid entityRef or missing annotation
+          description: Bad request - environment entity missing required annotations
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RequestError'
+        '404':
+          description: Not Found - environment entity not found in the catalog
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/RequestError'
         '500':
           description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RequestError'
+        '502':
+          description: Bad Gateway
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RequestError'
+        '503':
+          description: Service Unavailable
           content:
             application/json:
               schema:
@@ -273,13 +327,31 @@ paths:
                 items:
                   type: string
         '400':
-          description: Bad request - invalid entityRef or missing annotation
+          description: Bad request - environment entity missing required annotations
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RequestError'
+        '404':
+          description: Not Found - environment entity not found in the catalog
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/RequestError'
         '500':
           description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RequestError'
+        '502':
+          description: Bad Gateway
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RequestError'
+        '503':
+          description: Service Unavailable
           content:
             application/json:
               schema:
@@ -335,13 +407,31 @@ paths:
                 items:
                   type: string
         '400':
-          description: Bad request - invalid entityRef or missing annotation
+          description: Bad request - environment entity missing required annotations
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RequestError'
+        '404':
+          description: Not Found - environment entity not found in the catalog
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/RequestError'
         '500':
           description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RequestError'
+        '502':
+          description: Bad Gateway
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RequestError'
+        '503':
+          description: Service Unavailable
           content:
             application/json:
               schema:
@@ -397,13 +487,31 @@ paths:
                 items:
                   type: string
         '400':
-          description: Bad request - invalid entityRef or missing annotation
+          description: Bad request - environment entity missing required annotations
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RequestError'
+        '404':
+          description: Not Found - environment entity not found in the catalog
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/RequestError'
         '500':
           description: Internal server error - failed to fetch policies
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RequestError'
+        '502':
+          description: Bad Gateway
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RequestError'
+        '503':
+          description: Service Unavailable
           content:
             application/json:
               schema:

--- a/plugins/policy-reporter-backend/src/schema/openapi/generated/apis/Api.server.ts
+++ b/plugins/policy-reporter-backend/src/schema/openapi/generated/apis/Api.server.ts
@@ -19,7 +19,12 @@ export type GetCategories = {
     sources?: Array<string>;
     namespaces?: Array<string>;
   };
-  response: Array<string> | RequestError | RequestError;
+  response:
+    | Array<string>
+    | RequestError
+    | RequestError
+    | RequestError
+    | RequestError;
 };
 /**
  * @public
@@ -30,7 +35,12 @@ export type GetKinds = {
     sources?: Array<string>;
     namespaces?: Array<string>;
   };
-  response: Array<string> | RequestError | RequestError;
+  response:
+    | Array<string>
+    | RequestError
+    | RequestError
+    | RequestError
+    | RequestError;
 };
 /**
  * @public
@@ -64,7 +74,12 @@ export type GetNamespaces = {
     categories?: Array<string>;
     policies?: Array<string>;
   };
-  response: Array<string> | RequestError | RequestError;
+  response:
+    | Array<string>
+    | RequestError
+    | RequestError
+    | RequestError
+    | RequestError;
 };
 /**
  * @public
@@ -76,7 +91,12 @@ export type GetPolicies = {
     namespaces?: Array<string>;
     categories?: Array<string>;
   };
-  response: Array<string> | RequestError | RequestError;
+  response:
+    | Array<string>
+    | RequestError
+    | RequestError
+    | RequestError
+    | RequestError;
 };
 /**
  * @public
@@ -85,7 +105,12 @@ export type GetSources = {
   query: {
     environment: string;
   };
-  response: Array<string> | RequestError | RequestError;
+  response:
+    | Array<string>
+    | RequestError
+    | RequestError
+    | RequestError
+    | RequestError;
 };
 
 export type EndpointMap = {

--- a/plugins/policy-reporter-backend/src/schema/openapi/generated/router.ts
+++ b/plugins/policy-reporter-backend/src/schema/openapi/generated/router.ts
@@ -273,6 +273,26 @@ export const spec = {
               },
             },
           },
+          '502': {
+            description: 'Bad Gateway',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/RequestError',
+                },
+              },
+            },
+          },
+          '503': {
+            description: 'Service Unavailable',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/RequestError',
+                },
+              },
+            },
+          },
         },
       },
     },
@@ -355,6 +375,26 @@ export const spec = {
               },
             },
           },
+          '502': {
+            description: 'Bad Gateway',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/RequestError',
+                },
+              },
+            },
+          },
+          '503': {
+            description: 'Service Unavailable',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/RequestError',
+                },
+              },
+            },
+          },
         },
       },
     },
@@ -428,6 +468,26 @@ export const spec = {
           },
           '500': {
             description: 'Internal server error',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/RequestError',
+                },
+              },
+            },
+          },
+          '502': {
+            description: 'Bad Gateway',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/RequestError',
+                },
+              },
+            },
+          },
+          '503': {
+            description: 'Service Unavailable',
             content: {
               'application/json': {
                 schema: {
@@ -530,6 +590,26 @@ export const spec = {
               },
             },
           },
+          '502': {
+            description: 'Bad Gateway',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/RequestError',
+                },
+              },
+            },
+          },
+          '503': {
+            description: 'Service Unavailable',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/RequestError',
+                },
+              },
+            },
+          },
         },
       },
     },
@@ -616,6 +696,26 @@ export const spec = {
           },
           '500': {
             description: 'Internal server error - failed to fetch policies',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/RequestError',
+                },
+              },
+            },
+          },
+          '502': {
+            description: 'Bad Gateway',
+            content: {
+              'application/json': {
+                schema: {
+                  $ref: '#/components/schemas/RequestError',
+                },
+              },
+            },
+          },
+          '503': {
+            description: 'Service Unavailable',
             content: {
               'application/json': {
                 schema: {

--- a/plugins/policy-reporter-backend/src/service/policyReporterService.test.ts
+++ b/plugins/policy-reporter-backend/src/service/policyReporterService.test.ts
@@ -9,12 +9,6 @@ const authService = mockServices.auth.mock();
 const catalogService = catalogServiceMock({ entities: [] }) as CatalogService;
 
 describe('PolicyReporterService', () => {
-  const getDefaultHeaders = (
-    service: PolicyReporterService,
-  ): Record<string, string> => {
-    return Reflect.get(service, 'defaultHeaders') as Record<string, string>;
-  };
-
   it('creates service with default mocked rootConfig service', () => {
     const service = new PolicyReporterService({
       logger,
@@ -41,15 +35,14 @@ describe('PolicyReporterService', () => {
           data: {
             policyReporter: {
               requestHeaders: {
-                Authorization: 'Bearer test-token',
-                'X-Tenant': 'team-a',
+                ...headers,
               },
             },
           },
         }),
       });
 
-      expect(getDefaultHeaders(service)).toEqual({
+      expect(Reflect.get(service, 'defaultHeaders')).toEqual({
         'Content-Type': 'application/json',
         ...headers,
       });
@@ -63,7 +56,7 @@ describe('PolicyReporterService', () => {
         configService: mockServices.rootConfig(),
       });
 
-      expect(getDefaultHeaders(service)).toEqual({
+      expect(Reflect.get(service, 'defaultHeaders')).toEqual({
         'Content-Type': 'application/json',
       });
     });

--- a/plugins/policy-reporter-backend/src/service/policyReporterService.test.ts
+++ b/plugins/policy-reporter-backend/src/service/policyReporterService.test.ts
@@ -40,7 +40,7 @@ describe('PolicyReporterService', () => {
         configService: mockServices.rootConfig({
           data: {
             policyReporter: {
-              headers: {
+              requestHeaders: {
                 Authorization: 'Bearer test-token',
                 'X-Tenant': 'team-a',
               },

--- a/plugins/policy-reporter-backend/src/service/policyReporterService.test.ts
+++ b/plugins/policy-reporter-backend/src/service/policyReporterService.test.ts
@@ -1,0 +1,71 @@
+import { mockServices } from '@backstage/backend-test-utils';
+import { CatalogService } from '@backstage/plugin-catalog-node';
+import { catalogServiceMock } from '@backstage/plugin-catalog-node/testUtils';
+import { PolicyReporterService } from './policyReporterService';
+
+const logger = mockServices.logger.mock();
+const authService = mockServices.auth.mock();
+// catalogServiceMock currently returns a CatalogApi instead of CatalogService
+const catalogService = catalogServiceMock({ entities: [] }) as CatalogService;
+
+describe('PolicyReporterService', () => {
+  const getDefaultHeaders = (
+    service: PolicyReporterService,
+  ): Record<string, string> => {
+    return Reflect.get(service, 'defaultHeaders') as Record<string, string>;
+  };
+
+  it('creates service with default mocked rootConfig service', () => {
+    const service = new PolicyReporterService({
+      logger,
+      catalogService,
+      authService,
+      configService: mockServices.rootConfig(),
+    });
+
+    expect(service).toBeDefined();
+  });
+
+  describe('defaultHeaders', () => {
+    it('adds configured policyReporter.headers values while keeping Content-Type', () => {
+      const headers = {
+        Authorization: 'Bearer test-token',
+        'X-Tenant': 'team-a',
+      };
+
+      const service = new PolicyReporterService({
+        logger,
+        catalogService,
+        authService,
+        configService: mockServices.rootConfig({
+          data: {
+            policyReporter: {
+              headers: {
+                Authorization: 'Bearer test-token',
+                'X-Tenant': 'team-a',
+              },
+            },
+          },
+        }),
+      });
+
+      expect(getDefaultHeaders(service)).toEqual({
+        'Content-Type': 'application/json',
+        ...headers,
+      });
+    });
+
+    it('keeps defaultHeaders valid when policyReporter.headers is undefined', () => {
+      const service = new PolicyReporterService({
+        logger,
+        catalogService,
+        authService,
+        configService: mockServices.rootConfig(),
+      });
+
+      expect(getDefaultHeaders(service)).toEqual({
+        'Content-Type': 'application/json',
+      });
+    });
+  });
+});

--- a/plugins/policy-reporter-backend/src/service/policyReporterService.ts
+++ b/plugins/policy-reporter-backend/src/service/policyReporterService.ts
@@ -4,7 +4,11 @@ import {
   RootConfigService,
 } from '@backstage/backend-plugin-api';
 import * as parser from 'uri-template';
-import { ResultList } from '../schema/openapi/generated/models';
+import {
+  Filter,
+  Pagination,
+  ResultList,
+} from '../schema/openapi/generated/models';
 import { CatalogService } from '@backstage/plugin-catalog-node';
 import {
   ForwardedError,
@@ -15,38 +19,38 @@ import {
 import { KYVERNO_ENDPOINT_ANNOTATION } from '@kyverno/backstage-plugin-policy-reporter-common';
 import { JsonObject } from '@backstage/types';
 
-type QueryParams = Record<string, unknown>;
-
 export interface PolicyReporterApi {
   getNamespacedResourceResults(options: {
     entityRef: string;
-    query: QueryParams;
+    query: Filter & Pagination;
   }): Promise<ResultList>;
 
   getNamespaces(options: {
     entityRef: string;
-    query: QueryParams;
+    query: Pick<Filter, 'sources' | 'categories' | 'policies'>;
   }): Promise<string[]>;
 
   getSources(options: { entityRef: string }): Promise<string[]>;
 
   getKinds(options: {
     entityRef: string;
-    query: QueryParams;
+    query: Pick<Filter, 'sources' | 'kinds'>;
   }): Promise<string[]>;
 
   getCategories(options: {
     entityRef: string;
-    query: QueryParams;
+    query: Pick<Filter, 'sources' | 'namespaces'>;
   }): Promise<string[]>;
 
   getPolicies(options: {
     entityRef: string;
-    query: QueryParams;
+    query: Pick<Filter, 'sources' | 'namespaces' | 'categories'>;
   }): Promise<string[]>;
 }
 
 export class PolicyReporterService implements PolicyReporterApi {
+  // TODO: Add testcase to verify that defaultHeaders property has expected values
+  // Do we need a getter or update it to protected to validate this when testing ?
   private readonly defaultHeaders: Record<string, string>;
 
   constructor(
@@ -57,6 +61,7 @@ export class PolicyReporterService implements PolicyReporterApi {
       configService: RootConfigService;
     },
   ) {
+    // TODO: Add testcase to verify undefined headers doesnt break anything
     const headers = this.deps.configService
       .getOptionalConfig('policyReporter.headers')
       ?.get<JsonObject>();
@@ -69,7 +74,7 @@ export class PolicyReporterService implements PolicyReporterApi {
 
   async getNamespacedResourceResults(options: {
     entityRef: string;
-    query: QueryParams;
+    query: Filter & Pagination;
   }): Promise<ResultList> {
     const baseUrl = await this.getBaseUrl(options.entityRef);
 
@@ -77,21 +82,21 @@ export class PolicyReporterService implements PolicyReporterApi {
       baseUrl,
       uriTemplate:
         'v1/namespaced-resources/results{?sources*,namespaces*,kinds*,resources*,categories*,policies*,status*,severities*,search,labels*,page,offset,direction}',
-      query: options.query,
+      query: { ...options.query },
       operation: 'fetch namespaced resource results',
     });
   }
 
   async getNamespaces(options: {
     entityRef: string;
-    query: QueryParams;
+    query: Pick<Filter, 'sources' | 'categories' | 'policies'>;
   }): Promise<string[]> {
     const baseUrl = await this.getBaseUrl(options.entityRef);
 
     return this.request<string[]>({
       baseUrl,
       uriTemplate: 'v1/namespaces{?sources*,categories*,policies*}',
-      query: options.query,
+      query: { ...options.query },
       operation: 'fetch namespaces',
     });
   }
@@ -109,7 +114,7 @@ export class PolicyReporterService implements PolicyReporterApi {
 
   async getKinds(options: {
     entityRef: string;
-    query: QueryParams;
+    query: Pick<Filter, 'sources' | 'namespaces'>;
   }): Promise<string[]> {
     const baseUrl = await this.getBaseUrl(options.entityRef);
 
@@ -123,7 +128,7 @@ export class PolicyReporterService implements PolicyReporterApi {
 
   async getCategories(options: {
     entityRef: string;
-    query: QueryParams;
+    query: Pick<Filter, 'sources' | 'namespaces'>;
   }): Promise<string[]> {
     const baseUrl = await this.getBaseUrl(options.entityRef);
 
@@ -137,7 +142,7 @@ export class PolicyReporterService implements PolicyReporterApi {
 
   async getPolicies(options: {
     entityRef: string;
-    query: QueryParams;
+    query: Pick<Filter, 'sources' | 'namespaces' | 'categories'>;
   }): Promise<string[]> {
     const baseUrl = await this.getBaseUrl(options.entityRef);
 
@@ -153,7 +158,7 @@ export class PolicyReporterService implements PolicyReporterApi {
   private async request<T>(options: {
     baseUrl: string;
     uriTemplate: string;
-    query: QueryParams;
+    query: Record<string, unknown>;
     operation: string;
   }): Promise<T> {
     const uri = parser.parse(options.uriTemplate).expand(options.query);
@@ -202,7 +207,7 @@ export class PolicyReporterService implements PolicyReporterApi {
     });
 
     if (!entity) {
-      throw new NotFoundError();
+      throw new NotFoundError('Entity not found');
     }
 
     const baseUrl = entity.metadata.annotations?.[KYVERNO_ENDPOINT_ANNOTATION];

--- a/plugins/policy-reporter-backend/src/service/policyReporterService.ts
+++ b/plugins/policy-reporter-backend/src/service/policyReporterService.ts
@@ -49,8 +49,6 @@ export interface PolicyReporterApi {
 }
 
 export class PolicyReporterService implements PolicyReporterApi {
-  // TODO: Add testcase to verify that defaultHeaders property has expected values
-  // Do we need a getter or update it to protected to validate this when testing ?
   private readonly defaultHeaders: Record<string, string>;
 
   constructor(
@@ -61,9 +59,8 @@ export class PolicyReporterService implements PolicyReporterApi {
       configService: RootConfigService;
     },
   ) {
-    // TODO: Add testcase to verify undefined headers doesnt break anything
     const headers = this.deps.configService
-      .getOptionalConfig('policyReporter.headers')
+      .getOptionalConfig('policyReporter.requestHeaders')
       ?.get<JsonObject>();
 
     this.defaultHeaders = {

--- a/plugins/policy-reporter-backend/src/service/policyReporterService.ts
+++ b/plugins/policy-reporter-backend/src/service/policyReporterService.ts
@@ -1,4 +1,8 @@
-import { AuthService, LoggerService } from '@backstage/backend-plugin-api';
+import {
+  AuthService,
+  LoggerService,
+  RootConfigService,
+} from '@backstage/backend-plugin-api';
 import * as parser from 'uri-template';
 import { ResultList } from '../schema/openapi/generated/models';
 import { CatalogService } from '@backstage/plugin-catalog-node';
@@ -9,23 +13,9 @@ import {
   ServiceUnavailableError,
 } from '@backstage/errors';
 import { KYVERNO_ENDPOINT_ANNOTATION } from '@kyverno/backstage-plugin-policy-reporter-common';
-
-function ensureTrailingSlash(url: string): string {
-  return url.endsWith('/') ? url : `${url}/`;
-}
+import { JsonObject } from '@backstage/types';
 
 type QueryParams = Record<string, unknown>;
-
-export class PolicyReporterServiceError extends Error {
-  constructor(
-    message: string,
-    readonly cause?: unknown,
-    readonly status?: number,
-  ) {
-    super(message);
-    this.name = 'PolicyReporterServiceError';
-  }
-}
 
 export interface PolicyReporterApi {
   getNamespacedResourceResults(options: {
@@ -57,13 +47,25 @@ export interface PolicyReporterApi {
 }
 
 export class PolicyReporterService implements PolicyReporterApi {
+  private readonly defaultHeaders: Record<string, string>;
+
   constructor(
     private readonly deps: {
       logger: LoggerService;
       catalogService: CatalogService;
       authService: AuthService;
+      configService: RootConfigService;
     },
-  ) {}
+  ) {
+    const headers = this.deps.configService
+      .getOptionalConfig('policyReporter.headers')
+      ?.get<JsonObject>();
+
+    this.defaultHeaders = {
+      'Content-Type': 'application/json',
+      ...headers,
+    };
+  }
 
   async getNamespacedResourceResults(options: {
     entityRef: string;
@@ -155,7 +157,7 @@ export class PolicyReporterService implements PolicyReporterApi {
     operation: string;
   }): Promise<T> {
     const uri = parser.parse(options.uriTemplate).expand(options.query);
-    const url = `${ensureTrailingSlash(options.baseUrl)}${uri}`;
+    const url = `${this.ensureTrailingSlash(options.baseUrl)}${uri}`;
 
     let response: Response;
 
@@ -163,7 +165,7 @@ export class PolicyReporterService implements PolicyReporterApi {
       response = await fetch(url, {
         method: 'GET',
         headers: {
-          'Content-Type': 'application/json',
+          ...this.defaultHeaders,
         },
       });
     } catch (error) {
@@ -186,6 +188,10 @@ export class PolicyReporterService implements PolicyReporterApi {
     }
 
     return (await response.json()) as T;
+  }
+
+  private ensureTrailingSlash(url: string): string {
+    return url.endsWith('/') ? url : `${url}/`;
   }
 
   private async getBaseUrl(entityRef: string): Promise<string> {

--- a/plugins/policy-reporter-backend/src/service/policyReporterService.ts
+++ b/plugins/policy-reporter-backend/src/service/policyReporterService.ts
@@ -1,0 +1,212 @@
+import { AuthService, LoggerService } from '@backstage/backend-plugin-api';
+import * as parser from 'uri-template';
+import { ResultList } from '../schema/openapi/generated/models';
+import { CatalogService } from '@backstage/plugin-catalog-node';
+import {
+  ForwardedError,
+  InputError,
+  NotFoundError,
+  ServiceUnavailableError,
+} from '@backstage/errors';
+import { KYVERNO_ENDPOINT_ANNOTATION } from '@kyverno/backstage-plugin-policy-reporter-common';
+
+function ensureTrailingSlash(url: string): string {
+  return url.endsWith('/') ? url : `${url}/`;
+}
+
+type QueryParams = Record<string, unknown>;
+
+export class PolicyReporterServiceError extends Error {
+  constructor(
+    message: string,
+    readonly cause?: unknown,
+    readonly status?: number,
+  ) {
+    super(message);
+    this.name = 'PolicyReporterServiceError';
+  }
+}
+
+export interface PolicyReporterApi {
+  getNamespacedResourceResults(options: {
+    entityRef: string;
+    query: QueryParams;
+  }): Promise<ResultList>;
+
+  getNamespaces(options: {
+    entityRef: string;
+    query: QueryParams;
+  }): Promise<string[]>;
+
+  getSources(options: { entityRef: string }): Promise<string[]>;
+
+  getKinds(options: {
+    entityRef: string;
+    query: QueryParams;
+  }): Promise<string[]>;
+
+  getCategories(options: {
+    entityRef: string;
+    query: QueryParams;
+  }): Promise<string[]>;
+
+  getPolicies(options: {
+    entityRef: string;
+    query: QueryParams;
+  }): Promise<string[]>;
+}
+
+export class PolicyReporterService implements PolicyReporterApi {
+  constructor(
+    private readonly deps: {
+      logger: LoggerService;
+      catalogService: CatalogService;
+      authService: AuthService;
+    },
+  ) {}
+
+  async getNamespacedResourceResults(options: {
+    entityRef: string;
+    query: QueryParams;
+  }): Promise<ResultList> {
+    const baseUrl = await this.getBaseUrl(options.entityRef);
+
+    return this.request<ResultList>({
+      baseUrl,
+      uriTemplate:
+        'v1/namespaced-resources/results{?sources*,namespaces*,kinds*,resources*,categories*,policies*,status*,severities*,search,labels*,page,offset,direction}',
+      query: options.query,
+      operation: 'fetch namespaced resource results',
+    });
+  }
+
+  async getNamespaces(options: {
+    entityRef: string;
+    query: QueryParams;
+  }): Promise<string[]> {
+    const baseUrl = await this.getBaseUrl(options.entityRef);
+
+    return this.request<string[]>({
+      baseUrl,
+      uriTemplate: 'v1/namespaces{?sources*,categories*,policies*}',
+      query: options.query,
+      operation: 'fetch namespaces',
+    });
+  }
+
+  async getSources(options: { entityRef: string }): Promise<string[]> {
+    const baseUrl = await this.getBaseUrl(options.entityRef);
+
+    return this.request<string[]>({
+      baseUrl,
+      uriTemplate: 'v1/namespaced-resources/sources',
+      query: {},
+      operation: 'fetch sources',
+    });
+  }
+
+  async getKinds(options: {
+    entityRef: string;
+    query: QueryParams;
+  }): Promise<string[]> {
+    const baseUrl = await this.getBaseUrl(options.entityRef);
+
+    return this.request<string[]>({
+      baseUrl,
+      uriTemplate: 'v1/namespaced-resources/kinds{?sources*,namespaces*}',
+      query: options.query,
+      operation: 'fetch kinds',
+    });
+  }
+
+  async getCategories(options: {
+    entityRef: string;
+    query: QueryParams;
+  }): Promise<string[]> {
+    const baseUrl = await this.getBaseUrl(options.entityRef);
+
+    return this.request<string[]>({
+      baseUrl,
+      uriTemplate: 'v1/namespaced-resources/categories{?sources*,namespaces*}',
+      query: options.query,
+      operation: 'fetch categories',
+    });
+  }
+
+  async getPolicies(options: {
+    entityRef: string;
+    query: QueryParams;
+  }): Promise<string[]> {
+    const baseUrl = await this.getBaseUrl(options.entityRef);
+
+    return this.request<string[]>({
+      baseUrl,
+      uriTemplate:
+        'v1/namespaced-resources/policies{?sources*,namespaces*,categories*}',
+      query: options.query,
+      operation: 'fetch policies',
+    });
+  }
+
+  private async request<T>(options: {
+    baseUrl: string;
+    uriTemplate: string;
+    query: QueryParams;
+    operation: string;
+  }): Promise<T> {
+    const uri = parser.parse(options.uriTemplate).expand(options.query);
+    const url = `${ensureTrailingSlash(options.baseUrl)}${uri}`;
+
+    let response: Response;
+
+    try {
+      response = await fetch(url, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+    } catch (error) {
+      this.deps.logger.error(`Failed to ${options.operation} from ${url}`);
+      throw new ServiceUnavailableError(
+        `Failed to ${options.operation}`,
+        error,
+      );
+    }
+
+    if (!response.ok) {
+      this.deps.logger.warn(
+        `Policy Reporter returned ${response.status} ${response.statusText} for ${url}`,
+      );
+
+      throw new ForwardedError(
+        `Failed to ${options.operation}: ${response.status} ${response.statusText}`,
+        new Error(response.statusText),
+      );
+    }
+
+    return (await response.json()) as T;
+  }
+
+  private async getBaseUrl(entityRef: string): Promise<string> {
+    const credentials = await this.deps.authService.getOwnServiceCredentials();
+
+    const entity = await this.deps.catalogService.getEntityByRef(entityRef, {
+      credentials,
+    });
+
+    if (!entity) {
+      throw new NotFoundError();
+    }
+
+    const baseUrl = entity.metadata.annotations?.[KYVERNO_ENDPOINT_ANNOTATION];
+
+    if (!baseUrl) {
+      throw new InputError(
+        `Entity missing '${KYVERNO_ENDPOINT_ANNOTATION}' annotation`,
+      );
+    }
+
+    return baseUrl;
+  }
+}

--- a/plugins/policy-reporter-backend/src/service/router.test.ts
+++ b/plugins/policy-reporter-backend/src/service/router.test.ts
@@ -7,6 +7,8 @@ import { Entity } from '@backstage/catalog-model';
 import { createRouter } from './router';
 import { catalogServiceMock } from '@backstage/plugin-catalog-node/testUtils';
 import { CatalogService } from '@backstage/plugin-catalog-node';
+import { PolicyReporterService } from './policyReporterService';
+import { KYVERNO_ENDPOINT_ANNOTATION } from '@kyverno/backstage-plugin-policy-reporter-common';
 
 const mockEntities: Entity[] = [
   {
@@ -100,14 +102,25 @@ describe('createRouter', () => {
 
   beforeAll(async () => {
     server.listen({});
+    const logger = mockServices.logger.mock();
+    const config = mockServices.rootConfig();
+    const authService = mockServices.auth();
+    // catalogServiceMock currently returns a CatalogApi instead of CatalogService
+    const catalogService = catalogServiceMock({
+      entities: mockEntities,
+    }) as CatalogService;
+
+    const policyReporterService = new PolicyReporterService({
+      logger,
+      configService: config,
+      catalogService,
+      authService,
+    });
+
     const router = await createRouter({
-      logger: mockServices.logger.mock(),
-      config: mockServices.rootConfig(),
-      authService: mockServices.auth(),
-      // catalogServiceMock currently returns a CatalogApi instead of CatalogService
-      catalogService: catalogServiceMock({
-        entities: mockEntities,
-      }) as CatalogService,
+      logger,
+      config,
+      policyReporterService,
     });
     app = express().use(router);
   });
@@ -127,18 +140,18 @@ describe('createRouter', () => {
 
       expect(response.status).toBe(400);
       expect(response.body).toStrictEqual({
-        error: `Entity missing 'kyverno.io/endpoint' annotation`,
+        error: `Entity missing '${KYVERNO_ENDPOINT_ANNOTATION}' annotation`,
       });
     });
 
-    it('Should return 400 if entity is invalid', async () => {
+    it('Should return 404 if entity is not found in catalog', async () => {
       const response = await request(app).get(
         `/namespaced-resources/results?environment=resource%3Adefault%2Finvalid`,
       );
 
-      expect(response.status).toBe(400);
+      expect(response.status).toBe(404);
       expect(response.body).toStrictEqual({
-        error: `Invalid entityRef`,
+        error: 'Entity not found',
       });
     });
 
@@ -162,18 +175,18 @@ describe('createRouter', () => {
 
       expect(response.status).toBe(400);
       expect(response.body).toStrictEqual({
-        error: `Entity missing 'kyverno.io/endpoint' annotation`,
+        error: `Entity missing '${KYVERNO_ENDPOINT_ANNOTATION}' annotation`,
       });
     });
 
-    it('Should return 400 if entity is invalid', async () => {
+    it('Should return 404 if entity is not found in the catalog', async () => {
       const response = await request(app).get(
         `/v1/namespaces?environment=resource%3Adefault%2Finvalid`,
       );
 
-      expect(response.status).toBe(400);
+      expect(response.status).toBe(404);
       expect(response.body).toStrictEqual({
-        error: `Invalid entityRef`,
+        error: 'Entity not found',
       });
     });
 
@@ -195,18 +208,18 @@ describe('createRouter', () => {
 
       expect(response.status).toBe(400);
       expect(response.body).toStrictEqual({
-        error: `Entity missing 'kyverno.io/endpoint' annotation`,
+        error: `Entity missing '${KYVERNO_ENDPOINT_ANNOTATION}' annotation`,
       });
     });
 
-    it('Should return 400 if entity is invalid', async () => {
+    it('Should return 404 if entity is not found in the catalog', async () => {
       const response = await request(app).get(
         `/v1/namespaced-resources/sources?environment=resource%3Adefault%2Finvalid`,
       );
 
-      expect(response.status).toBe(400);
+      expect(response.status).toBe(404);
       expect(response.body).toStrictEqual({
-        error: `Invalid entityRef`,
+        error: 'Entity not found',
       });
     });
 
@@ -232,14 +245,14 @@ describe('createRouter', () => {
       });
     });
 
-    it('Should return 400 if entity is invalid', async () => {
+    it('Should return 404 if entity is not found in the catalog', async () => {
       const response = await request(app).get(
         `/v1/namespaced-resources/kinds?environment=resource%3Adefault%2Finvalid`,
       );
 
-      expect(response.status).toBe(400);
+      expect(response.status).toBe(404);
       expect(response.body).toStrictEqual({
-        error: `Invalid entityRef`,
+        error: 'Entity not found',
       });
     });
 
@@ -265,14 +278,14 @@ describe('createRouter', () => {
       });
     });
 
-    it('Should return 400 if entity is invalid', async () => {
+    it('Should return 404 if entity is not found in the catalog', async () => {
       const response = await request(app).get(
         `/v1/namespaced-resources/categories?environment=resource%3Adefault%2Finvalid`,
       );
 
-      expect(response.status).toBe(400);
+      expect(response.status).toBe(404);
       expect(response.body).toStrictEqual({
-        error: `Invalid entityRef`,
+        error: 'Entity not found',
       });
     });
 
@@ -302,14 +315,14 @@ describe('createRouter', () => {
       });
     });
 
-    it('Should return 400 if entity is invalid', async () => {
+    it('Should return 404 if entity is not found in the catalog', async () => {
       const response = await request(app).get(
         `/v1/namespaced-resources/policies?environment=resource%3Adefault%2Finvalid`,
       );
 
-      expect(response.status).toBe(400);
+      expect(response.status).toBe(404);
       expect(response.body).toStrictEqual({
-        error: `Invalid entityRef`,
+        error: 'Entity not found',
       });
     });
 

--- a/plugins/policy-reporter-backend/src/service/router.ts
+++ b/plugins/policy-reporter-backend/src/service/router.ts
@@ -1,12 +1,16 @@
 import { AuthService, RootConfigService } from '@backstage/backend-plugin-api';
 import { LoggerService } from '@backstage/backend-plugin-api';
 import express from 'express';
-import { KYVERNO_ENDPOINT_ANNOTATION } from '@kyverno/backstage-plugin-policy-reporter-common';
 import { MiddlewareFactory } from '@backstage/backend-defaults/rootHttpRouter';
 import { CatalogService } from '@backstage/plugin-catalog-node';
 import { createOpenApiRouter } from '../schema/openapi';
-
-import * as parser from 'uri-template';
+import { PolicyReporterService } from './policyReporterService';
+import {
+  ForwardedError,
+  InputError,
+  NotFoundError,
+  ServiceUnavailableError,
+} from '@backstage/errors';
 
 export interface RouterOptions {
   logger: LoggerService;
@@ -15,297 +19,133 @@ export interface RouterOptions {
   authService: AuthService;
 }
 
-const ensureTrailingSlash = (url: string) =>
-  url.endsWith('/') ? url : `${url}/`;
+function handlePolicyReporterError(
+  error: unknown,
+  response: express.Response,
+): express.Response {
+  if (error instanceof NotFoundError) {
+    return response.status(404).json({ error: error.message });
+  }
+
+  if (error instanceof InputError) {
+    return response.status(400).json({ error: error.message });
+  }
+
+  if (error instanceof ServiceUnavailableError) {
+    return response.status(503).json({ error: error.message });
+  }
+
+  if (error instanceof ForwardedError) {
+    return response.status(502).json({ error: error.message });
+  }
+
+  return response.status(500).json({ error: 'Unknown error' });
+}
 
 export async function createRouter(
   options: RouterOptions,
 ): Promise<express.Router> {
   const { logger, config, catalogService, authService } = options;
 
+  const policyReporterService = new PolicyReporterService({
+    logger,
+    catalogService,
+    authService,
+  });
+
   const router = await createOpenApiRouter();
   router.use(express.json());
 
   router.get('/namespaced-resources/results', async (request, response) => {
-    // Get entityRef from query.
-    const entityRef = decodeURIComponent(request.query.environment);
+    try {
+      const entityRef = decodeURIComponent(String(request.query.environment));
 
-    const credentials = await authService.getOwnServiceCredentials();
-
-    const entity = await catalogService.getEntityByRef(entityRef, {
-      credentials,
-    });
-
-    if (!entity)
-      return response.status(400).json({ error: 'Invalid entityRef' });
-
-    const kyvernoEndpoint =
-      entity?.metadata.annotations?.[KYVERNO_ENDPOINT_ANNOTATION];
-
-    if (!kyvernoEndpoint)
-      return response
-        .status(400)
-        .json({ error: `Entity missing 'kyverno.io/endpoint' annotation` });
-
-    const uriTemplate = `v1/namespaced-resources/results{?sources*,namespaces*,kinds*,resources*,categories*,policies*,status*,severities*,search,labels*,page,offset,direction}`;
-
-    const uri = parser.parse(uriTemplate).expand({
-      ...request.query,
-    });
-
-    const policyResponse = await fetch(
-      `${ensureTrailingSlash(kyvernoEndpoint)}${uri}`,
-      {
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        method: 'GET',
-      },
-    );
-
-    if (!policyResponse.ok) {
-      return response.status(500).json({
-        error: `Failed to fetch policies ${policyResponse.status} ${policyResponse.statusText}`,
+      const result = await policyReporterService.getNamespacedResourceResults({
+        entityRef,
+        query: request.query,
       });
+
+      return response.status(200).json(result);
+    } catch (error) {
+      return handlePolicyReporterError(error, response);
     }
-
-    const result = await policyResponse.json();
-
-    return response.status(200).json(result);
   });
 
   router.get('/v1/namespaces', async (request, response) => {
-    // Get entityRef from query.
-    const entityRef = decodeURIComponent(request.query.environment);
+    try {
+      const entityRef = decodeURIComponent(String(request.query.environment));
 
-    const credentials = await authService.getOwnServiceCredentials();
-    const entity = await catalogService.getEntityByRef(entityRef, {
-      credentials,
-    });
-
-    if (!entity) {
-      return response.status(400).json({ error: 'Invalid entityRef' });
-    }
-
-    const kyvernoEndpoint =
-      entity?.metadata.annotations?.[KYVERNO_ENDPOINT_ANNOTATION];
-
-    if (!kyvernoEndpoint) {
-      return response
-        .status(400)
-        .json({ error: `Entity missing 'kyverno.io/endpoint' annotation` });
-    }
-
-    const uriTemplate = `v1/namespaces{?sources*,categories*,policies*}`;
-
-    const uri = parser.parse(uriTemplate).expand({
-      ...request.query,
-    });
-
-    const policyResponse = await fetch(
-      `${ensureTrailingSlash(kyvernoEndpoint)}${uri}`,
-      {
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        method: 'GET',
-      },
-    );
-
-    if (!policyResponse.ok) {
-      return response.status(500).json({
-        error: `Failed to fetch namespaces: ${policyResponse.statusText}`,
+      const result = await policyReporterService.getNamespaces({
+        entityRef,
+        query: request.query,
       });
-    }
 
-    const result = await policyResponse.json();
-    return response.status(200).json(result);
+      return response.status(200).json(result);
+    } catch (error) {
+      return handlePolicyReporterError(error, response);
+    }
   });
 
   router.get('/v1/namespaced-resources/sources', async (request, response) => {
-    // Get entityRef from query.
-    const entityRef = decodeURIComponent(request.query.environment);
+    try {
+      const entityRef = decodeURIComponent(String(request.query.environment));
 
-    const credentials = await authService.getOwnServiceCredentials();
-    const entity = await catalogService.getEntityByRef(entityRef, {
-      credentials,
-    });
-
-    if (!entity) {
-      return response.status(400).json({ error: 'Invalid entityRef' });
-    }
-
-    const kyvernoEndpoint =
-      entity?.metadata.annotations?.[KYVERNO_ENDPOINT_ANNOTATION];
-
-    if (!kyvernoEndpoint) {
-      return response
-        .status(400)
-        .json({ error: `Entity missing 'kyverno.io/endpoint' annotation` });
-    }
-
-    const policyResponse = await fetch(
-      `${ensureTrailingSlash(kyvernoEndpoint)}v1/namespaced-resources/sources`,
-      {
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        method: 'GET',
-      },
-    );
-
-    if (!policyResponse.ok) {
-      return response.status(500).json({
-        error: `Failed to fetch sources: ${policyResponse.statusText}`,
+      const result = await policyReporterService.getSources({
+        entityRef,
       });
-    }
 
-    const result = await policyResponse.json();
-    return response.status(200).json(result);
+      return response.status(200).json(result);
+    } catch (error) {
+      return handlePolicyReporterError(error, response);
+    }
   });
 
   router.get('/v1/namespaced-resources/kinds', async (request, response) => {
-    const entityRef = decodeURIComponent(request.query.environment);
+    try {
+      const entityRef = decodeURIComponent(String(request.query.environment));
 
-    const credentials = await authService.getOwnServiceCredentials();
-    const entity = await catalogService.getEntityByRef(entityRef, {
-      credentials,
-    });
-
-    if (!entity) {
-      return response.status(400).json({ error: 'Invalid entityRef' });
-    }
-
-    const kyvernoEndpoint =
-      entity?.metadata.annotations?.[KYVERNO_ENDPOINT_ANNOTATION];
-
-    if (!kyvernoEndpoint) {
-      return response
-        .status(400)
-        .json({ error: `Entity missing 'kyverno.io/endpoint' annotation` });
-    }
-
-    const uriTemplate = `v1/namespaced-resources/kinds{?sources*,namespaces*}`;
-
-    const uri = parser.parse(uriTemplate).expand({
-      ...request.query,
-    });
-
-    const policyResponse = await fetch(
-      `${ensureTrailingSlash(kyvernoEndpoint)}${uri}`,
-      {
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        method: 'GET',
-      },
-    );
-
-    if (!policyResponse.ok) {
-      return response.status(500).json({
-        error: `Failed to fetch kinds: ${policyResponse.statusText}`,
+      const result = await policyReporterService.getKinds({
+        entityRef,
+        query: request.query,
       });
-    }
 
-    const result = await policyResponse.json();
-    return response.status(200).json(result);
+      return response.status(200).json(result);
+    } catch (error) {
+      return handlePolicyReporterError(error, response);
+    }
   });
 
   router.get(
     '/v1/namespaced-resources/categories',
     async (request, response) => {
-      // Get entityRef from query.
-      const entityRef = decodeURIComponent(request.query.environment);
+      try {
+        const entityRef = decodeURIComponent(String(request.query.environment));
 
-      const credentials = await authService.getOwnServiceCredentials();
-      const entity = await catalogService.getEntityByRef(entityRef, {
-        credentials,
-      });
-
-      if (!entity) {
-        return response.status(400).json({ error: 'Invalid entityRef' });
-      }
-
-      const kyvernoEndpoint =
-        entity?.metadata.annotations?.[KYVERNO_ENDPOINT_ANNOTATION];
-
-      if (!kyvernoEndpoint) {
-        return response
-          .status(400)
-          .json({ error: `Entity missing 'kyverno.io/endpoint' annotation` });
-      }
-
-      const uriTemplate = `v1/namespaced-resources/categories{?sources*,namespaces*}`;
-      const uri = parser.parse(uriTemplate).expand({
-        ...request.query,
-      });
-
-      const policyResponse = await fetch(
-        `${ensureTrailingSlash(kyvernoEndpoint)}${uri}`,
-        {
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          method: 'GET',
-        },
-      );
-
-      if (!policyResponse.ok) {
-        return response.status(500).json({
-          error: `Failed to fetch categories: ${policyResponse.statusText}`,
+        const result = await policyReporterService.getCategories({
+          entityRef,
+          query: request.query,
         });
-      }
 
-      const result = await policyResponse.json();
-      return response.status(200).json(result);
+        return response.status(200).json(result);
+      } catch (error) {
+        return handlePolicyReporterError(error, response);
+      }
     },
   );
 
   router.get('/v1/namespaced-resources/policies', async (request, response) => {
-    // Get entityRef from query.
-    const entityRef = decodeURIComponent(request.query.environment);
+    try {
+      const entityRef = decodeURIComponent(String(request.query.environment));
 
-    const credentials = await authService.getOwnServiceCredentials();
-    const entity = await catalogService.getEntityByRef(entityRef, {
-      credentials,
-    });
-
-    if (!entity) {
-      return response.status(400).json({ error: 'Invalid entityRef' });
-    }
-
-    const kyvernoEndpoint =
-      entity?.metadata.annotations?.[KYVERNO_ENDPOINT_ANNOTATION];
-
-    if (!kyvernoEndpoint) {
-      return response
-        .status(400)
-        .json({ error: `Entity missing 'kyverno.io/endpoint' annotation` });
-    }
-
-    const uriTemplate = `v1/namespaced-resources/policies{?sources*,namespaces*,categories*}`;
-    const uri = parser.parse(uriTemplate).expand({
-      ...request.query,
-    });
-
-    const policyResponse = await fetch(
-      `${ensureTrailingSlash(kyvernoEndpoint)}${uri}`,
-      {
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        method: 'GET',
-      },
-    );
-
-    if (!policyResponse.ok) {
-      return response.status(500).json({
-        error: `Failed to fetch policies: ${policyResponse.statusText}`,
+      const result = await policyReporterService.getPolicies({
+        entityRef,
+        query: request.query,
       });
-    }
 
-    const result = await policyResponse.json();
-    return response.status(200).json(result);
+      return response.status(200).json(result);
+    } catch (error) {
+      return handlePolicyReporterError(error, response);
+    }
   });
 
   const middleware = MiddlewareFactory.create({ logger, config });

--- a/plugins/policy-reporter-backend/src/service/router.ts
+++ b/plugins/policy-reporter-backend/src/service/router.ts
@@ -1,10 +1,9 @@
-import { AuthService, RootConfigService } from '@backstage/backend-plugin-api';
+import { RootConfigService } from '@backstage/backend-plugin-api';
 import { LoggerService } from '@backstage/backend-plugin-api';
 import express from 'express';
 import { MiddlewareFactory } from '@backstage/backend-defaults/rootHttpRouter';
-import { CatalogService } from '@backstage/plugin-catalog-node';
 import { createOpenApiRouter } from '../schema/openapi';
-import { PolicyReporterService } from './policyReporterService';
+import { PolicyReporterApi } from './policyReporterService';
 import {
   ForwardedError,
   InputError,
@@ -15,8 +14,7 @@ import {
 export interface RouterOptions {
   logger: LoggerService;
   config: RootConfigService;
-  catalogService: CatalogService;
-  authService: AuthService;
+  policyReporterService: PolicyReporterApi;
 }
 
 function handlePolicyReporterError(
@@ -45,25 +43,18 @@ function handlePolicyReporterError(
 export async function createRouter(
   options: RouterOptions,
 ): Promise<express.Router> {
-  const { logger, config, catalogService, authService } = options;
-
-  const policyReporterService = new PolicyReporterService({
-    logger,
-    catalogService,
-    authService,
-    configService: config,
-  });
+  const { logger, config, policyReporterService } = options;
 
   const router = await createOpenApiRouter();
   router.use(express.json());
 
   router.get('/namespaced-resources/results', async (request, response) => {
     try {
-      const entityRef = decodeURIComponent(String(request.query.environment));
+      const { environment, ...query } = request.query;
 
       const result = await policyReporterService.getNamespacedResourceResults({
-        entityRef,
-        query: request.query,
+        entityRef: decodeURIComponent(environment),
+        query: query,
       });
 
       return response.status(200).json(result);
@@ -74,11 +65,11 @@ export async function createRouter(
 
   router.get('/v1/namespaces', async (request, response) => {
     try {
-      const entityRef = decodeURIComponent(String(request.query.environment));
+      const { environment, ...query } = request.query;
 
       const result = await policyReporterService.getNamespaces({
-        entityRef,
-        query: request.query,
+        entityRef: decodeURIComponent(environment),
+        query: query,
       });
 
       return response.status(200).json(result);
@@ -89,10 +80,10 @@ export async function createRouter(
 
   router.get('/v1/namespaced-resources/sources', async (request, response) => {
     try {
-      const entityRef = decodeURIComponent(String(request.query.environment));
+      const { environment } = request.query;
 
       const result = await policyReporterService.getSources({
-        entityRef,
+        entityRef: decodeURIComponent(environment),
       });
 
       return response.status(200).json(result);
@@ -103,11 +94,11 @@ export async function createRouter(
 
   router.get('/v1/namespaced-resources/kinds', async (request, response) => {
     try {
-      const entityRef = decodeURIComponent(String(request.query.environment));
+      const { environment, ...query } = request.query;
 
       const result = await policyReporterService.getKinds({
-        entityRef,
-        query: request.query,
+        entityRef: decodeURIComponent(environment),
+        query,
       });
 
       return response.status(200).json(result);
@@ -120,11 +111,11 @@ export async function createRouter(
     '/v1/namespaced-resources/categories',
     async (request, response) => {
       try {
-        const entityRef = decodeURIComponent(String(request.query.environment));
+        const { environment, ...query } = request.query;
 
         const result = await policyReporterService.getCategories({
-          entityRef,
-          query: request.query,
+          entityRef: decodeURIComponent(environment),
+          query,
         });
 
         return response.status(200).json(result);
@@ -136,11 +127,11 @@ export async function createRouter(
 
   router.get('/v1/namespaced-resources/policies', async (request, response) => {
     try {
-      const entityRef = decodeURIComponent(String(request.query.environment));
+      const { environment, ...query } = request.query;
 
       const result = await policyReporterService.getPolicies({
-        entityRef,
-        query: request.query,
+        entityRef: decodeURIComponent(environment),
+        query,
       });
 
       return response.status(200).json(result);

--- a/plugins/policy-reporter-backend/src/service/router.ts
+++ b/plugins/policy-reporter-backend/src/service/router.ts
@@ -51,6 +51,7 @@ export async function createRouter(
     logger,
     catalogService,
     authService,
+    configService: config,
   });
 
   const router = await createOpenApiRouter();

--- a/yarn.lock
+++ b/yarn.lock
@@ -3420,7 +3420,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/errors@npm:^1.3.1":
+"@backstage/errors@backstage:^::backstage=1.52.0&npm=1.3.1, @backstage/errors@npm:^1.3.1":
   version: 1.3.1
   resolution: "@backstage/errors@npm:1.3.1"
   dependencies:
@@ -6328,6 +6328,7 @@ __metadata:
     "@backstage/catalog-model": "backstage:^"
     "@backstage/cli": "backstage:^"
     "@backstage/config": "backstage:^"
+    "@backstage/errors": "backstage:^"
     "@backstage/plugin-auth-backend": "backstage:^"
     "@backstage/plugin-auth-backend-module-guest-provider": "backstage:^"
     "@backstage/plugin-catalog-backend": "backstage:^"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4395,7 +4395,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@backstage/types@npm:^1.2.2":
+"@backstage/types@backstage:^::backstage=1.52.0&npm=1.2.2, @backstage/types@npm:^1.2.2":
   version: 1.2.2
   resolution: "@backstage/types@npm:1.2.2"
   checksum: 10c0/3c947cf83c058a56b0cfd90d91483e9a5c1c913f7978a0d5a3c0fd9b502d08e9bdf279afba626826eee84159e698ee4cdaa70040789ac47fc8a25df9f1925612
@@ -6334,6 +6334,7 @@ __metadata:
     "@backstage/plugin-catalog-backend": "backstage:^"
     "@backstage/plugin-catalog-node": "backstage:^"
     "@backstage/repo-tools": "backstage:^"
+    "@backstage/types": "backstage:^"
     "@kyverno/backstage-plugin-policy-reporter-common": "workspace:^"
     "@types/express": "npm:*"
     "@types/supertest": "npm:^2.0.12"


### PR DESCRIPTION
This PR adds a new service responsible for handling the API request to the policy reporter backend.

It's now also possible to configure requestHeaders that would be included in all request, this can be used for authentication headers. Based on the following [PR](https://github.com/kyverno/backstage-policy-reporter-plugin/pull/119)

I have added test cases for the new functionality to the policyReporterService.

I have also updated the error handling to so that the API can now also return 404(Entity missing), 502(Policy Reporter error response) and 503(failed to fetch) responses