### PR TITLE
Revert "chore(deps): Bump changesets/action from 1.9.0 to 2.0.0 in the github-actions-group group"

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Publish
         id: changesets
-        uses: changesets/action@22ccf9aa43179fe9e27dc62e575971d28cce197c
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d
         with:
           version: node .github/changeset-version.cjs
           publish: yarn publish


### PR DESCRIPTION
Reverts kyverno/backstage-policy-reporter-plugin#134

We need to bump the changeset version at the same time -  I would like to bundle the PR